### PR TITLE
Bugfixes and Variable Type Segment fields

### DIFF
--- a/lib/DataType/EdDataType.php
+++ b/lib/DataType/EdDataType.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Hl7v2\DataType;
+
+/**
+ * Encapsulated Data (ED).
+ */
+class EdDataType extends ComponentDataType
+{
+    /**
+     * @var \Hl7v2\DataType\HdDataType
+     */
+    private $sourceApplication;
+    /**
+     * @var \Hl7v2\DataType\IdDataType
+     */
+    private $typeOfData;
+    /**
+     * @var \Hl7v2\DataType\IdDataType
+     */
+    private $dataSubtype;
+    /**
+     * @var \Hl7v2\DataType\IdDataType
+     */
+    private $encoding;
+    /**
+     * @var \Hl7v2\DataType\TxDataType
+     */
+    private $data;
+
+    /**
+     * @param string $sourceApplicationNamespaceId
+     * @param string $sourceApplicationUniversalId
+     * @param string $sourceApplicationUniversalIdType
+     */
+    public function setSourceApplication(
+        $sourceApplicationNamespaceId,
+        $sourceApplicationUniversalId,
+        $sourceApplicationUniversalIdType
+    ) {
+        $this->sourceApplication = $this
+            ->dataTypeFactory
+            ->create('HD', $this->characterEncoding)
+        ;
+        $this->sourceApplication->setNamespaceId($sourceApplicationNamespaceId);
+        $this->sourceApplication->setUniversalId(
+            $sourceApplicationUniversalId,
+            $sourceApplicationUniversalIdType
+        );
+    }
+
+    /**
+     * @param string $typeOfData
+     */
+    public function setTypeOfData($typeOfData)
+    {
+        $this->typeOfData = $this
+            ->dataTypeFactory
+            ->create('ID', $this->characterEncoding)
+        ;
+        $this->typeOfData->setValue($typeOfData);
+    }
+
+    /**
+     * @param string $dataSubtype
+     */
+    public function setDataSubtype($dataSubtype = null)
+    {
+        $this->dataSubtype = $this
+            ->dataTypeFactory
+            ->create('ID', $this->characterEncoding)
+        ;
+        $this->dataSubtype->setValue($dataSubtype);
+    }
+
+    /**
+     * @param string $encoding
+     */
+    public function setEncoding($encoding)
+    {
+        $this->encoding = $this
+            ->dataTypeFactory
+            ->create('ID', $this->characterEncoding)
+        ;
+        $this->encoding->setValue($encoding);
+    }
+
+    /**
+     * @param string $data
+     */
+    public function setData($data)
+    {
+        $this->data = $this
+            ->dataTypeFactory
+            ->create('TX', $this->characterEncoding)
+        ;
+        $this->data->setValue($data);
+    }
+
+    /**
+     * @return \Hl7v2\DataType\HdDataType
+     */
+    public function getSourceApplication()
+    {
+        return $this->sourceApplication;
+    }
+
+    /**
+     * @return \Hl7v2\DataType\IdDataType
+     */
+    public function getTypeOfData()
+    {
+        return $this->typeOfData;
+    }
+
+    /**
+     * @return \Hl7v2\DataType\IdDataType
+     */
+    public function getDataSubtype()
+    {
+        return $this->dataSubtype;
+    }
+
+    /**
+     * @return \Hl7v2\DataType\IdDataType
+     */
+    public function getEncoding()
+    {
+        return $this->encoding;
+    }
+
+    /**
+     * @return \Hl7v2\DataType\TxDataType
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+}

--- a/lib/DataType/FtDataType.php
+++ b/lib/DataType/FtDataType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Hl7v2\DataType;
+
+/**
+ * Formatted Text (FT).
+ */
+class FtDataType extends StDataType
+{
+    const MAX_LEN = null;
+}

--- a/lib/DataType/IdDataType.php
+++ b/lib/DataType/IdDataType.php
@@ -7,4 +7,5 @@ namespace Hl7v2\DataType;
  */
 class IdDataType extends StDataType
 {
+    const MAX_LEN = null;
 }

--- a/lib/Encoding/Codec.php
+++ b/lib/Encoding/Codec.php
@@ -460,9 +460,6 @@ class Codec
             $length = $pos->eoc - $pos->soc;
         }
 
-        $pos->ptr = $pos->eoc;
-        $pos->state = PositionalState::END_COMPONENT;
-
         return mb_substr($data->value, $pos->soc, $length, $param->getCharacterEncoding());
     }
 
@@ -524,9 +521,6 @@ class Codec
         if (false !== $pos->eosc) {
             $length = $pos->eosc - $pos->sosc;
         }
-
-        $pos->ptr = $pos->eosc;
-        $pos->state = PositionalState::END_SUBCOMPONENT;
 
         return mb_substr($data->value, $pos->sosc, $length, $param->getCharacterEncoding());
     }

--- a/lib/Segment/AbstractSegment.php
+++ b/lib/Segment/AbstractSegment.php
@@ -32,14 +32,7 @@ abstract class AbstractSegment implements SegmentInterface
         $this->dataTypeFactory = $dataTypeFactory;
     }
 
-    /**
-     * Decode the Segment, from the supplied Datagram, using the Codec.
-     *
-     * @param \Hl7v2\Encoding\Datagram $data
-     * @param \Hl7v2\Encoding\Codec $codec
-     * @throws \Hl7v2\Exception\SegmentError
-     */
-    abstract public function fromDatagram(Datagram $data, Codec $codec);
+    abstract public function fromDatagram(Datagram $datagram, Codec $codec);
 
     /**
      * Having advanced in to a Field, this helper extracts the content of

--- a/lib/Segment/MshSegment.php
+++ b/lib/Segment/MshSegment.php
@@ -605,14 +605,14 @@ class MshSegment extends AbstractSegment
         return $this->messageProfileIdentifier;
     }
 
-    public function fromDatagram(Datagram $data, Codec $codec)
+    public function fromDatagram(Datagram $datagram, Codec $codec)
     {
         // MSH.1
-        $encodingParams = $data->getEncodingParameters();
+        $encodingParams = $datagram->getEncodingParameters();
         $this->setFieldFieldSeparator($encodingParams->getFieldSep());
 
         // MSH.2
-        $codec->advanceToField($data);
+        $codec->advanceToField($datagram);
         $this->setFieldEncodingCharacters(
             $encodingParams->getComponentSep()
             . $encodingParams->getRepetitionSep()
@@ -621,18 +621,18 @@ class MshSegment extends AbstractSegment
         );
 
         // MSH.3
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'MSH Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('SendingApplication', 227, $data->getPositionalState());
+        $this->checkFieldLength('SendingApplication', 227, $datagram->getPositionalState());
         $sequence = [1,1,1];
         list(
             $namespaceId,
             $universalId,
             $universalIdType,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldSendingApplication(
             $namespaceId,
             $universalId,
@@ -640,18 +640,18 @@ class MshSegment extends AbstractSegment
         );
 
         // MSH.4
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'MSH Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('SendingFacility', 227, $data->getPositionalState());
+        $this->checkFieldLength('SendingFacility', 227, $datagram->getPositionalState());
         $sequence = [1,1,1];
         list(
             $namespaceId,
             $universalId,
             $universalIdType,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldSendingFacility(
             $namespaceId,
             $universalId,
@@ -659,18 +659,18 @@ class MshSegment extends AbstractSegment
         );
 
         // MSH.5
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'MSH Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('ReceivingApplication', 227, $data->getPositionalState());
+        $this->checkFieldLength('ReceivingApplication', 227, $datagram->getPositionalState());
         $sequence = [1,1,1];
         list(
             $namespaceId,
             $universalId,
             $universalIdType,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldReceivingApplication(
             $namespaceId,
             $universalId,
@@ -678,18 +678,18 @@ class MshSegment extends AbstractSegment
         );
 
         // MSH.6
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'MSH Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('ReceivingFacility', 227, $data->getPositionalState());
+        $this->checkFieldLength('ReceivingFacility', 227, $datagram->getPositionalState());
         $sequence = [1,1,1];
         list(
             $namespaceId,
             $universalId,
             $universalIdType,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldReceivingFacility(
             $namespaceId,
             $universalId,
@@ -697,44 +697,44 @@ class MshSegment extends AbstractSegment
         );
 
         // MSH.7
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'MSH Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('DateTimeOfMessage', 26, $data->getPositionalState());
+        $this->checkFieldLength('DateTimeOfMessage', 26, $datagram->getPositionalState());
         $sequence = [1,1];
         list(
             $time,
             $degreeOfPrecision,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldDateTimeOfMessage(
             $time,
             $degreeOfPrecision
         );
 
         // MSH.8
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'MSH Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('Security', 40, $data->getPositionalState());
-        $this->setFieldSecurity($codec->extractComponent($data));
+        $this->checkFieldLength('Security', 40, $datagram->getPositionalState());
+        $this->setFieldSecurity($codec->extractComponent($datagram));
 
         // MSH.9
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'MSH Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('MessageType', 15, $data->getPositionalState());
+        $this->checkFieldLength('MessageType', 15, $datagram->getPositionalState());
         $sequence = [1,1,1];
         list(
             $messageCode,
             $triggerEvent,
             $messageStructure,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldMessageType(
             $messageCode,
             $triggerEvent,
@@ -742,38 +742,38 @@ class MshSegment extends AbstractSegment
         );
 
         // MSH.10
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'MSH Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('MessageControlId', 20, $data->getPositionalState());
-        $this->setFieldMessageControlId($codec->extractComponent($data));
+        $this->checkFieldLength('MessageControlId', 20, $datagram->getPositionalState());
+        $this->setFieldMessageControlId($codec->extractComponent($datagram));
 
         // MSH.11
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'MSH Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('ProcessingId', 3, $data->getPositionalState());
+        $this->checkFieldLength('ProcessingId', 3, $datagram->getPositionalState());
         $sequence = [1,1];
         list(
             $processingId,
             $processingMode,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldProcessingId(
             $processingId,
             $processingMode
         );
 
         // MSH.12
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'MSH Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('VersionId', 60, $data->getPositionalState());
+        $this->checkFieldLength('VersionId', 60, $datagram->getPositionalState());
         $sequence = [1,[1,1,1,1,1,1],[1,1,1,1,1,1]];
         list(
             $versionId,
@@ -793,7 +793,7 @@ class MshSegment extends AbstractSegment
                 $internationalisationVersionIdAltText,
                 $internationalisationVersionIdNameOfAltCodingSystem,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldVersionId(
             $versionId,
             $internationalisationCodeIdentifier,
@@ -811,49 +811,49 @@ class MshSegment extends AbstractSegment
         );
 
         // MSH.13
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('SequenceNumber', 15, $data->getPositionalState());
-        $this->setFieldSequenceNumber($codec->extractComponent($data));
+        $this->checkFieldLength('SequenceNumber', 15, $datagram->getPositionalState());
+        $this->setFieldSequenceNumber($codec->extractComponent($datagram));
 
         // MSH.14
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('ContinuationPointer', 180, $data->getPositionalState());
-        $this->setFieldContinuationPointer($codec->extractComponent($data));
+        $this->checkFieldLength('ContinuationPointer', 180, $datagram->getPositionalState());
+        $this->setFieldContinuationPointer($codec->extractComponent($datagram));
 
         // MSH.15
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('AcceptAcknowledgmentType', 2, $data->getPositionalState());
-        $this->setFieldAcceptAcknowledgmentType($codec->extractComponent($data));
+        $this->checkFieldLength('AcceptAcknowledgmentType', 2, $datagram->getPositionalState());
+        $this->setFieldAcceptAcknowledgmentType($codec->extractComponent($datagram));
 
         // MSH.16
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('ApplicationAcknowledgmentType', 2, $data->getPositionalState());
-        $this->setFieldApplicationAcknowledgmentType($codec->extractComponent($data));
+        $this->checkFieldLength('ApplicationAcknowledgmentType', 2, $datagram->getPositionalState());
+        $this->setFieldApplicationAcknowledgmentType($codec->extractComponent($datagram));
 
         // MSH.17
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('CountryCode', 3, $data->getPositionalState());
-        $this->setFieldCountryCode($codec->extractComponent($data));
+        $this->checkFieldLength('CountryCode', 3, $datagram->getPositionalState());
+        $this->setFieldCountryCode($codec->extractComponent($datagram));
 
         // MSH.18
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('CharacterSet', 16, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, [1]);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('CharacterSet', 16, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, [1]);
             $first = false;
         }
         foreach ($repetitions as list($value,)) {
@@ -861,10 +861,10 @@ class MshSegment extends AbstractSegment
         }
 
         // MSH.19
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PrincipalLanguageOfMessage', 250, $data->getPositionalState());
+        $this->checkFieldLength('PrincipalLanguageOfMessage', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1];
         list(
             $identifier,
@@ -873,7 +873,7 @@ class MshSegment extends AbstractSegment
             $altIdentifier,
             $altText,
             $nameOfAltCodingSystem,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldPrincipalLanguageOfMessage(
             $identifier,
             $text,
@@ -884,22 +884,22 @@ class MshSegment extends AbstractSegment
         );
 
         // MSH.20
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('AltCharacterSetHandlingScheme', 20, $data->getPositionalState());
-        $this->setFieldAltCharacterSetHandlingScheme($codec->extractComponent($data));
+        $this->checkFieldLength('AltCharacterSetHandlingScheme', 20, $datagram->getPositionalState());
+        $this->setFieldAltCharacterSetHandlingScheme($codec->extractComponent($datagram));
 
         // MSH.21
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('MessageProfileIdentifier', 427, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('MessageProfileIdentifier', 427, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {

--- a/lib/Segment/ObrSegment.php
+++ b/lib/Segment/ObrSegment.php
@@ -2595,31 +2595,31 @@ class ObrSegment extends AbstractSegment
         return $this->parentUniversalServiceIdentifier;
     }
 
-    public function fromDatagram(Datagram $data, Codec $codec)
+    public function fromDatagram(Datagram $datagram, Codec $codec)
     {
         // OBR.1
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'OBR Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('SetId', 4, $data->getPositionalState());
-        $this->setFieldSetId($codec->extractComponent($data));
+        $this->checkFieldLength('SetId', 4, $datagram->getPositionalState());
+        $this->setFieldSetId($codec->extractComponent($datagram));
 
         // OBR.2
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'OBR Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('PlacerOrderNumber', 22, $data->getPositionalState());
+        $this->checkFieldLength('PlacerOrderNumber', 22, $datagram->getPositionalState());
         $sequence = [1,1,1,1];
         list(
             $entityIdentifier,
             $namespaceId,
             $universalId,
             $universalIdType,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldPlacerOrderNumber(
             $entityIdentifier,
             $namespaceId,
@@ -2628,19 +2628,19 @@ class ObrSegment extends AbstractSegment
         );
 
         // OBR.3
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'OBR Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('FillerOrderNumber', 22, $data->getPositionalState());
+        $this->checkFieldLength('FillerOrderNumber', 22, $datagram->getPositionalState());
         $sequence = [1,1,1,1];
         list(
             $entityIdentifier,
             $namespaceId,
             $universalId,
             $universalIdType,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldFillerOrderNumber(
             $entityIdentifier,
             $namespaceId,
@@ -2649,12 +2649,12 @@ class ObrSegment extends AbstractSegment
         );
 
         // OBR.4
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'OBR Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('UniversalServiceIdentifier', 250, $data->getPositionalState());
+        $this->checkFieldLength('UniversalServiceIdentifier', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1];
         list(
             $identifier,
@@ -2663,7 +2663,7 @@ class ObrSegment extends AbstractSegment
             $altIdentifier,
             $altText,
             $nameOfAltCodingSystem,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldUniversalServiceIdentifier(
             $identifier,
             $text,
@@ -2674,62 +2674,62 @@ class ObrSegment extends AbstractSegment
         );
 
         // OBR.5
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('Priority', 2, $data->getPositionalState());
-        $this->setFieldPriority($codec->extractComponent($data));
+        $this->checkFieldLength('Priority', 2, $datagram->getPositionalState());
+        $this->setFieldPriority($codec->extractComponent($datagram));
 
         // OBR.6
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('RequestedDatetime', 26, $data->getPositionalState());
+        $this->checkFieldLength('RequestedDatetime', 26, $datagram->getPositionalState());
         $sequence = [1,1];
         list(
             $time,
             $degreeOfPrecision,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldRequestedDatetime(
             $time,
             $degreeOfPrecision
         );
 
         // OBR.7
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('ObservationDatetime', 26, $data->getPositionalState());
+        $this->checkFieldLength('ObservationDatetime', 26, $datagram->getPositionalState());
         $sequence = [1,1];
         list(
             $time,
             $degreeOfPrecision,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldObservationDatetime(
             $time,
             $degreeOfPrecision
         );
 
         // OBR.8
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('ObservationEndDatetime', 26, $data->getPositionalState());
+        $this->checkFieldLength('ObservationEndDatetime', 26, $datagram->getPositionalState());
         $sequence = [1,1];
         list(
             $time,
             $degreeOfPrecision,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldObservationEndDatetime(
             $time,
             $degreeOfPrecision
         );
 
         // OBR.9
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('CollectionVolume', 20, $data->getPositionalState());
+        $this->checkFieldLength('CollectionVolume', 20, $datagram->getPositionalState());
         $sequence = [1,[1,1,1,1,1,1]];
         list(
             $quantity,
@@ -2741,7 +2741,7 @@ class ObrSegment extends AbstractSegment
                 $unitsAltText,
                 $unitsNameOfAltCodingSystem,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldCollectionVolume(
             $quantity,
             $unitsIdentifier,
@@ -2753,15 +2753,15 @@ class ObrSegment extends AbstractSegment
         );
 
         // OBR.10
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,[1,1,1,1,1],1,1,1,1,1,1,[1,1,1],1,1,1,1,[1,1,1],1,[1,1,1,1,1,1],[[1,1],[1,1]],1,[1,1],[1,1],1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('CollectorIdentifier', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('CollectorIdentifier', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -2908,17 +2908,17 @@ class ObrSegment extends AbstractSegment
         }
 
         // OBR.11
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('SpecimenActionCode', 1, $data->getPositionalState());
-        $this->setFieldSpecimenActionCode($codec->extractComponent($data));
+        $this->checkFieldLength('SpecimenActionCode', 1, $datagram->getPositionalState());
+        $this->setFieldSpecimenActionCode($codec->extractComponent($datagram));
 
         // OBR.12
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('DangerCode', 250, $data->getPositionalState());
+        $this->checkFieldLength('DangerCode', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1];
         list(
             $identifier,
@@ -2927,7 +2927,7 @@ class ObrSegment extends AbstractSegment
             $altIdentifier,
             $altText,
             $nameOfAltCodingSystem,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldDangerCode(
             $identifier,
             $text,
@@ -2938,44 +2938,44 @@ class ObrSegment extends AbstractSegment
         );
 
         // OBR.13
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('RelevantClinicalInformation', 300, $data->getPositionalState());
-        $this->setFieldRelevantClinicalInformation($codec->extractComponent($data));
+        $this->checkFieldLength('RelevantClinicalInformation', 300, $datagram->getPositionalState());
+        $this->setFieldRelevantClinicalInformation($codec->extractComponent($datagram));
 
         // OBR.14
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('SpecimenReceivedDatetime', 26, $data->getPositionalState());
+        $this->checkFieldLength('SpecimenReceivedDatetime', 26, $datagram->getPositionalState());
         $sequence = [1,1];
         list(
             $time,
             $degreeOfPrecision,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldSpecimenReceivedDatetime(
             $time,
             $degreeOfPrecision
         );
 
         // OBR.15
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('SpecimenSource', 300, $data->getPositionalState());
-        $this->setFieldSpecimenSource($codec->extractComponent($data));
+        $this->checkFieldLength('SpecimenSource', 300, $datagram->getPositionalState());
+        $this->setFieldSpecimenSource($codec->extractComponent($datagram));
 
         // OBR.16
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,[1,1,1,1,1],1,1,1,1,1,1,[1,1,1],1,1,1,1,[1,1,1],1,[1,1,1,1,1,1],[[1,1],[1,1]],1,[1,1],[1,1],1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('OrderingProvider', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('OrderingProvider', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3122,15 +3122,15 @@ class ObrSegment extends AbstractSegment
         }
 
         // OBR.17
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1,1,1,1,1,1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('OrderCallbackPhoneNumber', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('OrderCallbackPhoneNumber', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3165,53 +3165,53 @@ class ObrSegment extends AbstractSegment
         }
 
         // OBR.18
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PlacerField1', 60, $data->getPositionalState());
-        $this->setFieldPlacerField1($codec->extractComponent($data));
+        $this->checkFieldLength('PlacerField1', 60, $datagram->getPositionalState());
+        $this->setFieldPlacerField1($codec->extractComponent($datagram));
 
         // OBR.19
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PlacerField2', 60, $data->getPositionalState());
-        $this->setFieldPlacerField2($codec->extractComponent($data));
+        $this->checkFieldLength('PlacerField2', 60, $datagram->getPositionalState());
+        $this->setFieldPlacerField2($codec->extractComponent($datagram));
 
         // OBR.20
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('FillerField1', 60, $data->getPositionalState());
-        $this->setFieldFillerField1($codec->extractComponent($data));
+        $this->checkFieldLength('FillerField1', 60, $datagram->getPositionalState());
+        $this->setFieldFillerField1($codec->extractComponent($datagram));
 
         // OBR.21
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('FillerField2', 60, $data->getPositionalState());
-        $this->setFieldFillerField2($codec->extractComponent($data));
+        $this->checkFieldLength('FillerField2', 60, $datagram->getPositionalState());
+        $this->setFieldFillerField2($codec->extractComponent($datagram));
 
         // OBR.22
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('ResultsRptstatusChngDatetime', 26, $data->getPositionalState());
+        $this->checkFieldLength('ResultsRptstatusChngDatetime', 26, $datagram->getPositionalState());
         $sequence = [1,1];
         list(
             $time,
             $degreeOfPrecision,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldResultsRptstatusChngDatetime(
             $time,
             $degreeOfPrecision
         );
 
         // OBR.23
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('ChargeToPractice', 40, $data->getPositionalState());
+        $this->checkFieldLength('ChargeToPractice', 40, $datagram->getPositionalState());
         $sequence = [[1,1],[1,1,1,1,1,1]];
         list(
             list(
@@ -3226,7 +3226,7 @@ class ObrSegment extends AbstractSegment
                 $chargeCodeAltText,
                 $chargeCodeNameOfAltCodingSystem,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldChargeToPractice(
             $monetaryAmountQuantity,
             $monetaryAmountDenomination,
@@ -3239,24 +3239,24 @@ class ObrSegment extends AbstractSegment
         );
 
         // OBR.24
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('DiagnosticServSectId', 10, $data->getPositionalState());
-        $this->setFieldDiagnosticServSectId($codec->extractComponent($data));
+        $this->checkFieldLength('DiagnosticServSectId', 10, $datagram->getPositionalState());
+        $this->setFieldDiagnosticServSectId($codec->extractComponent($datagram));
 
         // OBR.25
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('ResultStatus', 1, $data->getPositionalState());
-        $this->setFieldResultStatus($codec->extractComponent($data));
+        $this->checkFieldLength('ResultStatus', 1, $datagram->getPositionalState());
+        $this->setFieldResultStatus($codec->extractComponent($datagram));
 
         // OBR.26
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('ParentResult', 400, $data->getPositionalState());
+        $this->checkFieldLength('ParentResult', 400, $datagram->getPositionalState());
         $sequence = [[1,1,1,1,1,1],1,1];
         list(
             list(
@@ -3269,7 +3269,7 @@ class ObrSegment extends AbstractSegment
             ),
             $parentObservationSubIdentifier,
             $parentObservationValueDescriptor,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldParentResult(
             $parentObservationIdentifierIdentifier,
             $parentObservationIdentifierText,
@@ -3282,15 +3282,15 @@ class ObrSegment extends AbstractSegment
         );
 
         // OBR.27
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [[1,[1,1,1,1,1,1]],[1,1],1,[1,1],[1,1],1,1,1,1,[1,1,1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1],1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('Quantitytiming', 200, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('Quantitytiming', 200, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3387,15 +3387,15 @@ class ObrSegment extends AbstractSegment
         }
 
         // OBR.28
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,[1,1,1,1,1],1,1,1,1,1,1,[1,1,1],1,1,1,1,[1,1,1],1,[1,1,1,1,1,1],[[1,1],[1,1]],1,[1,1],[1,1],1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('ResultCopiesTo', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('ResultCopiesTo', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3542,10 +3542,10 @@ class ObrSegment extends AbstractSegment
         }
 
         // OBR.29
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('Parent', 200, $data->getPositionalState());
+        $this->checkFieldLength('Parent', 200, $datagram->getPositionalState());
         $sequence = [[1,1,1,1],[1,1,1,1]];
         list(
             list(
@@ -3560,7 +3560,7 @@ class ObrSegment extends AbstractSegment
                 $fillerAssignedIdentifierUniversalId,
                 $fillerAssignedIdentifierUniversalIdType,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldParent(
             $placerAssignedIdentifierEntityIdentifier,
             $placerAssignedIdentifierNamespaceId,
@@ -3573,22 +3573,22 @@ class ObrSegment extends AbstractSegment
         );
 
         // OBR.30
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('TransportationMode', 20, $data->getPositionalState());
-        $this->setFieldTransportationMode($codec->extractComponent($data));
+        $this->checkFieldLength('TransportationMode', 20, $datagram->getPositionalState());
+        $this->setFieldTransportationMode($codec->extractComponent($datagram));
 
         // OBR.31
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('ReasonForStudy', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('ReasonForStudy', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3611,10 +3611,10 @@ class ObrSegment extends AbstractSegment
         }
 
         // OBR.32
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PrincipalResultInterpreter', 200, $data->getPositionalState());
+        $this->checkFieldLength('PrincipalResultInterpreter', 200, $datagram->getPositionalState());
         $sequence = [[1,1,1,1,1,1,1,1,1,1,1],[1,1],[1,1],1,1,1,[1,1,1],1,1,1,1];
         list(
             list(
@@ -3650,7 +3650,7 @@ class ObrSegment extends AbstractSegment
             $patientLocationType,
             $building,
             $floor,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldPrincipalResultInterpreter(
             $nameIdNumber,
             $nameFamilyName,
@@ -3680,15 +3680,15 @@ class ObrSegment extends AbstractSegment
         );
 
         // OBR.33
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [[1,1,1,1,1,1,1,1,1,1,1],[1,1],[1,1],1,1,1,[1,1,1],1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('AssistantResultInterpreter', 200, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('AssistantResultInterpreter', 200, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3757,15 +3757,15 @@ class ObrSegment extends AbstractSegment
         }
 
         // OBR.34
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [[1,1,1,1,1,1,1,1,1,1,1],[1,1],[1,1],1,1,1,[1,1,1],1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('Technician', 200, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('Technician', 200, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3834,15 +3834,15 @@ class ObrSegment extends AbstractSegment
         }
 
         // OBR.35
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [[1,1,1,1,1,1,1,1,1,1,1],[1,1],[1,1],1,1,1,[1,1,1],1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('Transcriptionist', 200, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('Transcriptionist', 200, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3911,37 +3911,37 @@ class ObrSegment extends AbstractSegment
         }
 
         // OBR.36
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('ScheduledDatetime', 26, $data->getPositionalState());
+        $this->checkFieldLength('ScheduledDatetime', 26, $datagram->getPositionalState());
         $sequence = [1,1];
         list(
             $time,
             $degreeOfPrecision,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldScheduledDatetime(
             $time,
             $degreeOfPrecision
         );
 
         // OBR.37
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('NumberOfSampleContainers', 4, $data->getPositionalState());
-        $this->setFieldNumberOfSampleContainers($codec->extractComponent($data));
+        $this->checkFieldLength('NumberOfSampleContainers', 4, $datagram->getPositionalState());
+        $this->setFieldNumberOfSampleContainers($codec->extractComponent($datagram));
 
         // OBR.38
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('TransportLogisticsOfCollectedSample', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('TransportLogisticsOfCollectedSample', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3964,15 +3964,15 @@ class ObrSegment extends AbstractSegment
         }
 
         // OBR.39
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('CollectorsComment', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('CollectorsComment', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3995,10 +3995,10 @@ class ObrSegment extends AbstractSegment
         }
 
         // OBR.40
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('TransportArrangementResponsibility', 250, $data->getPositionalState());
+        $this->checkFieldLength('TransportArrangementResponsibility', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1];
         list(
             $identifier,
@@ -4007,7 +4007,7 @@ class ObrSegment extends AbstractSegment
             $altIdentifier,
             $altText,
             $nameOfAltCodingSystem,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldTransportArrangementResponsibility(
             $identifier,
             $text,
@@ -4018,29 +4018,29 @@ class ObrSegment extends AbstractSegment
         );
 
         // OBR.41
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('TransportArranged', 30, $data->getPositionalState());
-        $this->setFieldTransportArranged($codec->extractComponent($data));
+        $this->checkFieldLength('TransportArranged', 30, $datagram->getPositionalState());
+        $this->setFieldTransportArranged($codec->extractComponent($datagram));
 
         // OBR.42
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('EscortRequired', 1, $data->getPositionalState());
-        $this->setFieldEscortRequired($codec->extractComponent($data));
+        $this->checkFieldLength('EscortRequired', 1, $datagram->getPositionalState());
+        $this->setFieldEscortRequired($codec->extractComponent($datagram));
 
         // OBR.43
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('PlannedPatientTransportComment', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('PlannedPatientTransportComment', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -4063,10 +4063,10 @@ class ObrSegment extends AbstractSegment
         }
 
         // OBR.44
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('ProcedureCode', 250, $data->getPositionalState());
+        $this->checkFieldLength('ProcedureCode', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1];
         list(
             $identifier,
@@ -4075,7 +4075,7 @@ class ObrSegment extends AbstractSegment
             $altIdentifier,
             $altText,
             $nameOfAltCodingSystem,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldProcedureCode(
             $identifier,
             $text,
@@ -4086,15 +4086,15 @@ class ObrSegment extends AbstractSegment
         );
 
         // OBR.45
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('ProcedureCodeModifier', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('ProcedureCodeModifier', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -4117,15 +4117,15 @@ class ObrSegment extends AbstractSegment
         }
 
         // OBR.46
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('PlacerSupplementalServiceInformation', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('PlacerSupplementalServiceInformation', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -4148,15 +4148,15 @@ class ObrSegment extends AbstractSegment
         }
 
         // OBR.47
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('FillerSupplementalServiceInformation', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('FillerSupplementalServiceInformation', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -4179,10 +4179,10 @@ class ObrSegment extends AbstractSegment
         }
 
         // OBR.48
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('MedicallyNecessaryDuplicateProcedureReason', 250, $data->getPositionalState());
+        $this->checkFieldLength('MedicallyNecessaryDuplicateProcedureReason', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1,1,1,1];
         list(
             $identifier,
@@ -4194,7 +4194,7 @@ class ObrSegment extends AbstractSegment
             $codingSystemVersionId,
             $altCodingSystemVersionId,
             $originalText,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldMedicallyNecessaryDuplicateProcedureReason(
             $identifier,
             $text,
@@ -4208,17 +4208,17 @@ class ObrSegment extends AbstractSegment
         );
 
         // OBR.49
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('ResultHandling', 2, $data->getPositionalState());
-        $this->setFieldResultHandling($codec->extractComponent($data));
+        $this->checkFieldLength('ResultHandling', 2, $datagram->getPositionalState());
+        $this->setFieldResultHandling($codec->extractComponent($datagram));
 
         // OBR.50
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('ParentUniversalServiceIdentifier', 250, $data->getPositionalState());
+        $this->checkFieldLength('ParentUniversalServiceIdentifier', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1,1,1,1];
         list(
             $identifier,
@@ -4230,7 +4230,7 @@ class ObrSegment extends AbstractSegment
             $codingSystemVersionId,
             $altCodingSystemVersionId,
             $originalText,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldParentUniversalServiceIdentifier(
             $identifier,
             $text,

--- a/lib/Segment/ObrSegment.php
+++ b/lib/Segment/ObrSegment.php
@@ -2600,7 +2600,7 @@ class ObrSegment extends AbstractSegment
         // OBR.1
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'OBR Segment data contains too few required fields.'
             );
         }
         $this->checkFieldLength('SetId', 4, $data->getPositionalState());
@@ -2609,7 +2609,7 @@ class ObrSegment extends AbstractSegment
         // OBR.2
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'OBR Segment data contains too few required fields.'
             );
         }
         $this->checkFieldLength('PlacerOrderNumber', 22, $data->getPositionalState());
@@ -2630,7 +2630,7 @@ class ObrSegment extends AbstractSegment
         // OBR.3
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'OBR Segment data contains too few required fields.'
             );
         }
         $this->checkFieldLength('FillerOrderNumber', 22, $data->getPositionalState());
@@ -2651,7 +2651,7 @@ class ObrSegment extends AbstractSegment
         // OBR.4
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'OBR Segment data contains too few required fields.'
             );
         }
         $this->checkFieldLength('UniversalServiceIdentifier', 250, $data->getPositionalState());

--- a/lib/Segment/ObxSegment.php
+++ b/lib/Segment/ObxSegment.php
@@ -1121,33 +1121,33 @@ class ObxSegment extends AbstractSegment
         return $this->performingOrganizationMedicalDirector;
     }
 
-    public function fromDatagram(Datagram $data, Codec $codec)
+    public function fromDatagram(Datagram $datagram, Codec $codec)
     {
         // OBX.1
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'OBX Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('SetId', 4, $data->getPositionalState());
-        $this->setFieldSetId($codec->extractComponent($data));
+        $this->checkFieldLength('SetId', 4, $datagram->getPositionalState());
+        $this->setFieldSetId($codec->extractComponent($datagram));
 
         // OBX.2
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'OBX Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('ValueType', 2, $data->getPositionalState());
-        $this->setFieldValueType($codec->extractComponent($data));
+        $this->checkFieldLength('ValueType', 2, $datagram->getPositionalState());
+        $this->setFieldValueType($codec->extractComponent($datagram));
 
         // OBX.3
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'OBX Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('ObservationIdentifier', 250, $data->getPositionalState());
+        $this->checkFieldLength('ObservationIdentifier', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1];
         list(
             $identifier,
@@ -1156,7 +1156,7 @@ class ObxSegment extends AbstractSegment
             $altIdentifier,
             $altText,
             $nameOfAltCodingSystem,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldObservationIdentifier(
             $identifier,
             $text,
@@ -1167,24 +1167,24 @@ class ObxSegment extends AbstractSegment
         );
 
         // OBX.4
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'OBX Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('ObservationSubid', 20, $data->getPositionalState());
-        $this->setFieldObservationSubid($codec->extractComponent($data));
+        $this->checkFieldLength('ObservationSubid', 20, $datagram->getPositionalState());
+        $this->setFieldObservationSubid($codec->extractComponent($datagram));
 
         // OBX.5
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'OBX Segment data contains too few required fields.'
             );
         }
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $repetitions[] = $this->extractComponents($data, $codec, [1]);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $repetitions[] = $this->extractComponents($datagram, $codec, [1]);
             $first = false;
         }
         foreach ($repetitions as list($value,)) {
@@ -1192,12 +1192,12 @@ class ObxSegment extends AbstractSegment
         }
 
         // OBX.6
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'OBX Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('Units', 250, $data->getPositionalState());
+        $this->checkFieldLength('Units', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1];
         list(
             $identifier,
@@ -1206,7 +1206,7 @@ class ObxSegment extends AbstractSegment
             $altIdentifier,
             $altText,
             $nameOfAltCodingSystem,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldUnits(
             $identifier,
             $text,
@@ -1217,25 +1217,25 @@ class ObxSegment extends AbstractSegment
         );
 
         // OBX.7
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'OBX Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('ReferencesRange', 60, $data->getPositionalState());
-        $this->setFieldReferencesRange($codec->extractComponent($data));
+        $this->checkFieldLength('ReferencesRange', 60, $datagram->getPositionalState());
+        $this->setFieldReferencesRange($codec->extractComponent($datagram));
 
         // OBX.8
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'OBX Segment data contains too few required fields.'
             );
         }
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('AbnormalFlags', 5, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, [1]);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('AbnormalFlags', 5, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, [1]);
             $first = false;
         }
         foreach ($repetitions as list($value,)) {
@@ -1243,25 +1243,25 @@ class ObxSegment extends AbstractSegment
         }
 
         // OBX.9
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'OBX Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('Probability', 5, $data->getPositionalState());
-        $this->setFieldProbability($codec->extractComponent($data));
+        $this->checkFieldLength('Probability', 5, $datagram->getPositionalState());
+        $this->setFieldProbability($codec->extractComponent($datagram));
 
         // OBX.10
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'OBX Segment data contains too few required fields.'
             );
         }
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('NatureOfAbnormalTest', 2, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, [1]);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('NatureOfAbnormalTest', 2, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, [1]);
             $first = false;
         }
         foreach ($repetitions as list($value,)) {
@@ -1269,56 +1269,56 @@ class ObxSegment extends AbstractSegment
         }
 
         // OBX.11
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'OBX Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('ObservationResultStatus', 1, $data->getPositionalState());
-        $this->setFieldObservationResultStatus($codec->extractComponent($data));
+        $this->checkFieldLength('ObservationResultStatus', 1, $datagram->getPositionalState());
+        $this->setFieldObservationResultStatus($codec->extractComponent($datagram));
 
         // OBX.12
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('EffectiveDateOfReferenceRangeValues', 26, $data->getPositionalState());
+        $this->checkFieldLength('EffectiveDateOfReferenceRangeValues', 26, $datagram->getPositionalState());
         $sequence = [1,1];
         list(
             $time,
             $degreeOfPrecision,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldEffectiveDateOfReferenceRangeValues(
             $time,
             $degreeOfPrecision
         );
 
         // OBX.13
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('UserDefinedAccessChecks', 20, $data->getPositionalState());
-        $this->setFieldUserDefinedAccessChecks($codec->extractComponent($data));
+        $this->checkFieldLength('UserDefinedAccessChecks', 20, $datagram->getPositionalState());
+        $this->setFieldUserDefinedAccessChecks($codec->extractComponent($datagram));
 
         // OBX.14
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('DatetimeOfTheObservation', 26, $data->getPositionalState());
+        $this->checkFieldLength('DatetimeOfTheObservation', 26, $datagram->getPositionalState());
         $sequence = [1,1];
         list(
             $time,
             $degreeOfPrecision,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldDatetimeOfTheObservation(
             $time,
             $degreeOfPrecision
         );
 
         // OBX.15
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('ProducersReference', 250, $data->getPositionalState());
+        $this->checkFieldLength('ProducersReference', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1];
         list(
             $identifier,
@@ -1327,7 +1327,7 @@ class ObxSegment extends AbstractSegment
             $altIdentifier,
             $altText,
             $nameOfAltCodingSystem,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldProducersReference(
             $identifier,
             $text,
@@ -1338,15 +1338,15 @@ class ObxSegment extends AbstractSegment
         );
 
         // OBX.16
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,[1,1,1,1,1],1,1,1,1,1,1,[1,1,1],1,1,1,1,[1,1,1],1,[1,1,1,1,1,1],[[1,1],[1,1]],1,[1,1],[1,1],1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('ResponsibleObserver', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('ResponsibleObserver', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -1493,15 +1493,15 @@ class ObxSegment extends AbstractSegment
         }
 
         // OBX.17
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('ObservationMethod', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('ObservationMethod', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -1524,15 +1524,15 @@ class ObxSegment extends AbstractSegment
         }
 
         // OBX.18
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('EquipmentInstanceIdentifier', 22, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('EquipmentInstanceIdentifier', 22, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -1551,40 +1551,40 @@ class ObxSegment extends AbstractSegment
         }
 
         // OBX.19
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('DatetimeOfTheAnalysis', 26, $data->getPositionalState());
+        $this->checkFieldLength('DatetimeOfTheAnalysis', 26, $datagram->getPositionalState());
         $sequence = [1,1];
         list(
             $time,
             $degreeOfPrecision,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldDatetimeOfTheAnalysis(
             $time,
             $degreeOfPrecision
         );
 
         // OBX.20 (Skipped)
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
 
         // OBX.21 (Skipped)
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
 
         // OBX.22 (Skipped)
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
 
         // OBX.23
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PerformingOrganizationName', 567, $data->getPositionalState());
+        $this->checkFieldLength('PerformingOrganizationName', 567, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,[1,1,1],1,[1,1,1],1,1];
         list(
             $organisationName,
@@ -1605,7 +1605,7 @@ class ObxSegment extends AbstractSegment
             ),
             $nameRepresentationCode,
             $organisationIdentifier,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldPerformingOrganizationName(
             $organisationName,
             $organisationNameTypeCode,
@@ -1624,10 +1624,10 @@ class ObxSegment extends AbstractSegment
         );
 
         // OBX.24
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PerformingOrganizationAddress', 631, $data->getPositionalState());
+        $this->checkFieldLength('PerformingOrganizationAddress', 631, $datagram->getPositionalState());
         $sequence = [[1,1,1],1,1,1,1,1,1,1,1,1,1,[[1,1],[1,1]],[1,1],[1,1]];
         list(
             list(
@@ -1663,7 +1663,7 @@ class ObxSegment extends AbstractSegment
                 $expirationDateTime,
                 $expirationDateDegreeOfPrecision,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldPerformingOrganizationAddress(
             $streetAddressStreetOrMailingAddress,
             $streetAddressStreetName,
@@ -1689,10 +1689,10 @@ class ObxSegment extends AbstractSegment
         );
 
         // OBX.25
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PerformingOrganizationMedicalDirector', 3002, $data->getPositionalState());
+        $this->checkFieldLength('PerformingOrganizationMedicalDirector', 3002, $datagram->getPositionalState());
         $sequence = [1,[1,1,1,1,1],1,1,1,1,1,1,[1,1,1],1,1,1,1,[1,1,1],1,[1,1,1,1,1,1],[[1,1],[1,1]],1,[1,1],[1,1],1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         list(
             $idNumber,
@@ -1774,7 +1774,7 @@ class ObxSegment extends AbstractSegment
                 $assigningAgencyAltCodingSystemVersionId,
                 $assigningAgencyOriginalText,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldPerformingOrganizationMedicalDirector(
             $idNumber,
             $familyNameSurname,

--- a/lib/Segment/ObxSegment.php
+++ b/lib/Segment/ObxSegment.php
@@ -1126,7 +1126,7 @@ class ObxSegment extends AbstractSegment
         // OBX.1
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'OBX Segment data contains too few required fields.'
             );
         }
         $this->checkFieldLength('SetId', 4, $data->getPositionalState());
@@ -1135,7 +1135,7 @@ class ObxSegment extends AbstractSegment
         // OBX.2
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'OBX Segment data contains too few required fields.'
             );
         }
         $this->checkFieldLength('ValueType', 2, $data->getPositionalState());
@@ -1144,7 +1144,7 @@ class ObxSegment extends AbstractSegment
         // OBX.3
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'OBX Segment data contains too few required fields.'
             );
         }
         $this->checkFieldLength('ObservationIdentifier', 250, $data->getPositionalState());
@@ -1169,7 +1169,7 @@ class ObxSegment extends AbstractSegment
         // OBX.4
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'OBX Segment data contains too few required fields.'
             );
         }
         $this->checkFieldLength('ObservationSubid', 20, $data->getPositionalState());
@@ -1178,7 +1178,7 @@ class ObxSegment extends AbstractSegment
         // OBX.5
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'OBX Segment data contains too few required fields.'
             );
         }
         $repetitions = [];
@@ -1194,7 +1194,7 @@ class ObxSegment extends AbstractSegment
         // OBX.6
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'OBX Segment data contains too few required fields.'
             );
         }
         $this->checkFieldLength('Units', 250, $data->getPositionalState());
@@ -1219,7 +1219,7 @@ class ObxSegment extends AbstractSegment
         // OBX.7
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'OBX Segment data contains too few required fields.'
             );
         }
         $this->checkFieldLength('ReferencesRange', 60, $data->getPositionalState());
@@ -1228,7 +1228,7 @@ class ObxSegment extends AbstractSegment
         // OBX.8
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'OBX Segment data contains too few required fields.'
             );
         }
         $repetitions = [];
@@ -1245,7 +1245,7 @@ class ObxSegment extends AbstractSegment
         // OBX.9
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'OBX Segment data contains too few required fields.'
             );
         }
         $this->checkFieldLength('Probability', 5, $data->getPositionalState());
@@ -1254,7 +1254,7 @@ class ObxSegment extends AbstractSegment
         // OBX.10
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'OBX Segment data contains too few required fields.'
             );
         }
         $repetitions = [];
@@ -1271,7 +1271,7 @@ class ObxSegment extends AbstractSegment
         // OBX.11
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'OBX Segment data contains too few required fields.'
             );
         }
         $this->checkFieldLength('ObservationResultStatus', 1, $data->getPositionalState());

--- a/lib/Segment/PidSegment.php
+++ b/lib/Segment/PidSegment.php
@@ -2064,7 +2064,7 @@ class PidSegment extends AbstractSegment
         // PID.1
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'PID Segment data contains too few required fields.'
             );
         }
         $this->checkFieldLength('SetId', 4, $data->getPositionalState());
@@ -2073,7 +2073,7 @@ class PidSegment extends AbstractSegment
         // PID.2
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'PID Segment data contains too few required fields.'
             );
         }
         $this->checkFieldLength('PatientId', 20, $data->getPositionalState());
@@ -2154,7 +2154,7 @@ class PidSegment extends AbstractSegment
         // PID.3
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'PID Segment data contains too few required fields.'
             );
         }
         $sequence = [1,1,1,[1,1,1],1,[1,1,1],1,1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
@@ -2243,7 +2243,7 @@ class PidSegment extends AbstractSegment
         // PID.4
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'PID Segment data contains too few required fields.'
             );
         }
         $sequence = [1,1,1,[1,1,1],1,[1,1,1],1,1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
@@ -2332,7 +2332,7 @@ class PidSegment extends AbstractSegment
         // PID.5
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'PID Segment data contains too few required fields.'
             );
         }
         $sequence = [[1,1,1,1,1],1,1,1,1,1,1,1,[1,1,1,1,1,1],[[1,1],[1,1]],1,[1,1],[1,1],1];

--- a/lib/Segment/PidSegment.php
+++ b/lib/Segment/PidSegment.php
@@ -2059,24 +2059,24 @@ class PidSegment extends AbstractSegment
         return $this->tribalCitizenship;
     }
 
-    public function fromDatagram(Datagram $data, Codec $codec)
+    public function fromDatagram(Datagram $datagram, Codec $codec)
     {
         // PID.1
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'PID Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('SetId', 4, $data->getPositionalState());
-        $this->setFieldSetId($codec->extractComponent($data));
+        $this->checkFieldLength('SetId', 4, $datagram->getPositionalState());
+        $this->setFieldSetId($codec->extractComponent($datagram));
 
         // PID.2
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'PID Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('PatientId', 20, $data->getPositionalState());
+        $this->checkFieldLength('PatientId', 20, $datagram->getPositionalState());
         $sequence = [1,1,1,[1,1,1],1,[1,1,1],1,1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         list(
             $idNumber,
@@ -2117,7 +2117,7 @@ class PidSegment extends AbstractSegment
                 $assigningAgencyAltCodingSystemVersionId,
                 $assigningAgencyOriginalText,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldPatientId(
             $idNumber,
             $checkDigit,
@@ -2152,7 +2152,7 @@ class PidSegment extends AbstractSegment
         );
 
         // PID.3
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'PID Segment data contains too few required fields.'
             );
@@ -2160,9 +2160,9 @@ class PidSegment extends AbstractSegment
         $sequence = [1,1,1,[1,1,1],1,[1,1,1],1,1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('PatientIdentifierList', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('PatientIdentifierList', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -2241,7 +2241,7 @@ class PidSegment extends AbstractSegment
         }
 
         // PID.4
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'PID Segment data contains too few required fields.'
             );
@@ -2249,9 +2249,9 @@ class PidSegment extends AbstractSegment
         $sequence = [1,1,1,[1,1,1],1,[1,1,1],1,1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('AltPatientId', 20, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('AltPatientId', 20, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -2330,7 +2330,7 @@ class PidSegment extends AbstractSegment
         }
 
         // PID.5
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'PID Segment data contains too few required fields.'
             );
@@ -2338,9 +2338,9 @@ class PidSegment extends AbstractSegment
         $sequence = [[1,1,1,1,1],1,1,1,1,1,1,1,[1,1,1,1,1,1],[[1,1],[1,1]],1,[1,1],[1,1],1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('PatientName', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('PatientName', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -2421,15 +2421,15 @@ class PidSegment extends AbstractSegment
         }
 
         // PID.6
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [[1,1,1,1,1],1,1,1,1,1,1,1,[1,1,1,1,1,1],[[1,1],[1,1]],1,[1,1],[1,1],1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('MothersMaidenName', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('MothersMaidenName', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -2510,37 +2510,37 @@ class PidSegment extends AbstractSegment
         }
 
         // PID.7
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('DatetimeOfBirth', 26, $data->getPositionalState());
+        $this->checkFieldLength('DatetimeOfBirth', 26, $datagram->getPositionalState());
         $sequence = [1,1];
         list(
             $time,
             $degreeOfPrecision,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldDatetimeOfBirth(
             $time,
             $degreeOfPrecision
         );
 
         // PID.8
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('AdministrativeSex', 1, $data->getPositionalState());
-        $this->setFieldAdministrativeSex($codec->extractComponent($data));
+        $this->checkFieldLength('AdministrativeSex', 1, $datagram->getPositionalState());
+        $this->setFieldAdministrativeSex($codec->extractComponent($datagram));
 
         // PID.9
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [[1,1,1,1,1],1,1,1,1,1,1,1,[1,1,1,1,1,1],[[1,1],[1,1]],1,[1,1],[1,1],1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('PatientAlias', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('PatientAlias', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -2621,15 +2621,15 @@ class PidSegment extends AbstractSegment
         }
 
         // PID.10
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('Race', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('Race', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -2652,15 +2652,15 @@ class PidSegment extends AbstractSegment
         }
 
         // PID.11
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [[1,1,1],1,1,1,1,1,1,1,1,1,1,[[1,1],[1,1]],[1,1],[1,1]];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('PatientAddress', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('PatientAddress', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -2725,22 +2725,22 @@ class PidSegment extends AbstractSegment
         }
 
         // PID.12
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('CountyCode', 4, $data->getPositionalState());
-        $this->setFieldCountyCode($codec->extractComponent($data));
+        $this->checkFieldLength('CountyCode', 4, $datagram->getPositionalState());
+        $this->setFieldCountyCode($codec->extractComponent($datagram));
 
         // PID.13
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1,1,1,1,1,1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('PhoneNumberHome', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('PhoneNumberHome', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -2775,15 +2775,15 @@ class PidSegment extends AbstractSegment
         }
 
         // PID.14
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1,1,1,1,1,1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('PhoneNumberBusiness', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('PhoneNumberBusiness', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -2818,10 +2818,10 @@ class PidSegment extends AbstractSegment
         }
 
         // PID.15
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PrimaryLanguage', 250, $data->getPositionalState());
+        $this->checkFieldLength('PrimaryLanguage', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1];
         list(
             $identifier,
@@ -2830,7 +2830,7 @@ class PidSegment extends AbstractSegment
             $altIdentifier,
             $altText,
             $nameOfAltCodingSystem,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldPrimaryLanguage(
             $identifier,
             $text,
@@ -2841,10 +2841,10 @@ class PidSegment extends AbstractSegment
         );
 
         // PID.16
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('MaritalStatus', 250, $data->getPositionalState());
+        $this->checkFieldLength('MaritalStatus', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1];
         list(
             $identifier,
@@ -2853,7 +2853,7 @@ class PidSegment extends AbstractSegment
             $altIdentifier,
             $altText,
             $nameOfAltCodingSystem,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldMaritalStatus(
             $identifier,
             $text,
@@ -2864,10 +2864,10 @@ class PidSegment extends AbstractSegment
         );
 
         // PID.17
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('Religion', 250, $data->getPositionalState());
+        $this->checkFieldLength('Religion', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1];
         list(
             $identifier,
@@ -2876,7 +2876,7 @@ class PidSegment extends AbstractSegment
             $altIdentifier,
             $altText,
             $nameOfAltCodingSystem,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldReligion(
             $identifier,
             $text,
@@ -2887,10 +2887,10 @@ class PidSegment extends AbstractSegment
         );
 
         // PID.18
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PatientAccountNumber', 250, $data->getPositionalState());
+        $this->checkFieldLength('PatientAccountNumber', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,[1,1,1],1,[1,1,1],1,1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         list(
             $idNumber,
@@ -2931,7 +2931,7 @@ class PidSegment extends AbstractSegment
                 $assigningAgencyAltCodingSystemVersionId,
                 $assigningAgencyOriginalText,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldPatientAccountNumber(
             $idNumber,
             $checkDigit,
@@ -2966,23 +2966,23 @@ class PidSegment extends AbstractSegment
         );
 
         // PID.19
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('SsnNumberPatient', 16, $data->getPositionalState());
-        $this->setFieldSsnNumberPatient($codec->extractComponent($data));
+        $this->checkFieldLength('SsnNumberPatient', 16, $datagram->getPositionalState());
+        $this->setFieldSsnNumberPatient($codec->extractComponent($datagram));
 
         // PID.20
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('DriversLicenseNumberPatient', 25, $data->getPositionalState());
+        $this->checkFieldLength('DriversLicenseNumberPatient', 25, $datagram->getPositionalState());
         $sequence = [1,1,1];
         list(
             $licenseNumber,
             $issuingStateProvinceCountry,
             $expirationDate,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldDriversLicenseNumberPatient(
             $licenseNumber,
             $issuingStateProvinceCountry,
@@ -2990,15 +2990,15 @@ class PidSegment extends AbstractSegment
         );
 
         // PID.21
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,[1,1,1],1,[1,1,1],1,1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('MothersIdentifier', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('MothersIdentifier', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3077,15 +3077,15 @@ class PidSegment extends AbstractSegment
         }
 
         // PID.22
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('EthnicGroup', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('EthnicGroup', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3108,36 +3108,36 @@ class PidSegment extends AbstractSegment
         }
 
         // PID.23
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('BirthPlace', 250, $data->getPositionalState());
-        $this->setFieldBirthPlace($codec->extractComponent($data));
+        $this->checkFieldLength('BirthPlace', 250, $datagram->getPositionalState());
+        $this->setFieldBirthPlace($codec->extractComponent($datagram));
 
         // PID.24
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('MultipleBirthIndicator', 1, $data->getPositionalState());
-        $this->setFieldMultipleBirthIndicator($codec->extractComponent($data));
+        $this->checkFieldLength('MultipleBirthIndicator', 1, $datagram->getPositionalState());
+        $this->setFieldMultipleBirthIndicator($codec->extractComponent($datagram));
 
         // PID.25
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('BirthOrder', 2, $data->getPositionalState());
-        $this->setFieldBirthOrder($codec->extractComponent($data));
+        $this->checkFieldLength('BirthOrder', 2, $datagram->getPositionalState());
+        $this->setFieldBirthOrder($codec->extractComponent($datagram));
 
         // PID.26
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('Citizenship', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('Citizenship', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3160,10 +3160,10 @@ class PidSegment extends AbstractSegment
         }
 
         // PID.27
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('VeteransMilitaryStatus', 250, $data->getPositionalState());
+        $this->checkFieldLength('VeteransMilitaryStatus', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1];
         list(
             $identifier,
@@ -3172,7 +3172,7 @@ class PidSegment extends AbstractSegment
             $altIdentifier,
             $altText,
             $nameOfAltCodingSystem,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldVeteransMilitaryStatus(
             $identifier,
             $text,
@@ -3183,10 +3183,10 @@ class PidSegment extends AbstractSegment
         );
 
         // PID.28
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('Nationality', 250, $data->getPositionalState());
+        $this->checkFieldLength('Nationality', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1];
         list(
             $identifier,
@@ -3195,7 +3195,7 @@ class PidSegment extends AbstractSegment
             $altIdentifier,
             $altText,
             $nameOfAltCodingSystem,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldNationality(
             $identifier,
             $text,
@@ -3206,43 +3206,43 @@ class PidSegment extends AbstractSegment
         );
 
         // PID.29
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PatientDeathDateAndTime', 26, $data->getPositionalState());
+        $this->checkFieldLength('PatientDeathDateAndTime', 26, $datagram->getPositionalState());
         $sequence = [1,1];
         list(
             $time,
             $degreeOfPrecision,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldPatientDeathDateAndTime(
             $time,
             $degreeOfPrecision
         );
 
         // PID.30
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PatientDeathIndicator', 1, $data->getPositionalState());
-        $this->setFieldPatientDeathIndicator($codec->extractComponent($data));
+        $this->checkFieldLength('PatientDeathIndicator', 1, $datagram->getPositionalState());
+        $this->setFieldPatientDeathIndicator($codec->extractComponent($datagram));
 
         // PID.31
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('IdentityUnknownIndicator', 1, $data->getPositionalState());
-        $this->setFieldIdentityUnknownIndicator($codec->extractComponent($data));
+        $this->checkFieldLength('IdentityUnknownIndicator', 1, $datagram->getPositionalState());
+        $this->setFieldIdentityUnknownIndicator($codec->extractComponent($datagram));
 
         // PID.32
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('IdentityReliabilityCode', 20, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, [1]);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('IdentityReliabilityCode', 20, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, [1]);
             $first = false;
         }
         foreach ($repetitions as list($value,)) {
@@ -3250,31 +3250,31 @@ class PidSegment extends AbstractSegment
         }
 
         // PID.33
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('LastUpdateDatetime', 26, $data->getPositionalState());
+        $this->checkFieldLength('LastUpdateDatetime', 26, $datagram->getPositionalState());
         $sequence = [1,1];
         list(
             $time,
             $degreeOfPrecision,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldLastUpdateDatetime(
             $time,
             $degreeOfPrecision
         );
 
         // PID.34
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('LastUpdateFacility', 241, $data->getPositionalState());
+        $this->checkFieldLength('LastUpdateFacility', 241, $datagram->getPositionalState());
         $sequence = [1,1,1];
         list(
             $namespaceId,
             $universalId,
             $universalIdType,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldLastUpdateFacility(
             $namespaceId,
             $universalId,
@@ -3282,10 +3282,10 @@ class PidSegment extends AbstractSegment
         );
 
         // PID.35
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('SpeciesCode', 250, $data->getPositionalState());
+        $this->checkFieldLength('SpeciesCode', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1];
         list(
             $identifier,
@@ -3294,7 +3294,7 @@ class PidSegment extends AbstractSegment
             $altIdentifier,
             $altText,
             $nameOfAltCodingSystem,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldSpeciesCode(
             $identifier,
             $text,
@@ -3305,10 +3305,10 @@ class PidSegment extends AbstractSegment
         );
 
         // PID.36
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('BreedCode', 250, $data->getPositionalState());
+        $this->checkFieldLength('BreedCode', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1];
         list(
             $identifier,
@@ -3317,7 +3317,7 @@ class PidSegment extends AbstractSegment
             $altIdentifier,
             $altText,
             $nameOfAltCodingSystem,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldBreedCode(
             $identifier,
             $text,
@@ -3328,22 +3328,22 @@ class PidSegment extends AbstractSegment
         );
 
         // PID.37
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('Strain', 80, $data->getPositionalState());
-        $this->setFieldStrain($codec->extractComponent($data));
+        $this->checkFieldLength('Strain', 80, $datagram->getPositionalState());
+        $this->setFieldStrain($codec->extractComponent($datagram));
 
         // PID.38
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('ProductionClassCode', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('ProductionClassCode', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3366,15 +3366,15 @@ class PidSegment extends AbstractSegment
         }
 
         // PID.39
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1,1,1,1,1,1,1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('TribalCitizenship', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('TribalCitizenship', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {

--- a/lib/Segment/Pv1Segment.php
+++ b/lib/Segment/Pv1Segment.php
@@ -2796,31 +2796,31 @@ class Pv1Segment extends AbstractSegment
         return $this->otherHealthcareProvider;
     }
 
-    public function fromDatagram(Datagram $data, Codec $codec)
+    public function fromDatagram(Datagram $datagram, Codec $codec)
     {
         // PV1.1
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'PV1 Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('SetId', 4, $data->getPositionalState());
-        $this->setFieldSetId($codec->extractComponent($data));
+        $this->checkFieldLength('SetId', 4, $datagram->getPositionalState());
+        $this->setFieldSetId($codec->extractComponent($datagram));
 
         // PV1.2
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             throw new SegmentError(
                 'PV1 Segment data contains too few required fields.'
             );
         }
-        $this->checkFieldLength('PatientClass', 1, $data->getPositionalState());
-        $this->setFieldPatientClass($codec->extractComponent($data));
+        $this->checkFieldLength('PatientClass', 1, $datagram->getPositionalState());
+        $this->setFieldPatientClass($codec->extractComponent($datagram));
 
         // PV1.3
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('AssignedPatientLocation', 80, $data->getPositionalState());
+        $this->checkFieldLength('AssignedPatientLocation', 80, $datagram->getPositionalState());
         $sequence = [1,1,1,[1,1,1],1,1,1,1,1,[1,1,1,1],[1,1,1]];
         list(
             $pointOfCare,
@@ -2847,7 +2847,7 @@ class Pv1Segment extends AbstractSegment
                 $assigningAuthorityForLocationUniversalId,
                 $assigningAuthorityForLocationUniversalIdType,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldAssignedPatientLocation(
             $pointOfCare,
             $room,
@@ -2870,17 +2870,17 @@ class Pv1Segment extends AbstractSegment
         );
 
         // PV1.4
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('AdmissionType', 2, $data->getPositionalState());
-        $this->setFieldAdmissionType($codec->extractComponent($data));
+        $this->checkFieldLength('AdmissionType', 2, $datagram->getPositionalState());
+        $this->setFieldAdmissionType($codec->extractComponent($datagram));
 
         // PV1.5
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PreadmitNumber', 250, $data->getPositionalState());
+        $this->checkFieldLength('PreadmitNumber', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,[1,1,1],1,[1,1,1],1,1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         list(
             $idNumber,
@@ -2921,7 +2921,7 @@ class Pv1Segment extends AbstractSegment
                 $assigningAgencyAltCodingSystemVersionId,
                 $assigningAgencyOriginalText,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldPreadmitNumber(
             $idNumber,
             $checkDigit,
@@ -2956,10 +2956,10 @@ class Pv1Segment extends AbstractSegment
         );
 
         // PV1.6
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PriorPatientLocation', 80, $data->getPositionalState());
+        $this->checkFieldLength('PriorPatientLocation', 80, $datagram->getPositionalState());
         $sequence = [1,1,1,[1,1,1],1,1,1,1,1,[1,1,1,1],[1,1,1]];
         list(
             $pointOfCare,
@@ -2986,7 +2986,7 @@ class Pv1Segment extends AbstractSegment
                 $assigningAuthorityForLocationUniversalId,
                 $assigningAuthorityForLocationUniversalIdType,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldPriorPatientLocation(
             $pointOfCare,
             $room,
@@ -3009,15 +3009,15 @@ class Pv1Segment extends AbstractSegment
         );
 
         // PV1.7
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,[1,1,1,1,1],1,1,1,1,1,1,[1,1,1],1,1,1,1,[1,1,1],1,[1,1,1,1,1,1],[[1,1],[1,1]],1,[1,1],[1,1],1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('AttendingDoctor', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('AttendingDoctor', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3164,15 +3164,15 @@ class Pv1Segment extends AbstractSegment
         }
 
         // PV1.8
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,[1,1,1,1,1],1,1,1,1,1,1,[1,1,1],1,1,1,1,[1,1,1],1,[1,1,1,1,1,1],[[1,1],[1,1]],1,[1,1],[1,1],1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('ReferringDoctor', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('ReferringDoctor', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3319,15 +3319,15 @@ class Pv1Segment extends AbstractSegment
         }
 
         // PV1.9
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,[1,1,1,1,1],1,1,1,1,1,1,[1,1,1],1,1,1,1,[1,1,1],1,[1,1,1,1,1,1],[[1,1],[1,1]],1,[1,1],[1,1],1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('ConsultingDoctor', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('ConsultingDoctor', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3474,17 +3474,17 @@ class Pv1Segment extends AbstractSegment
         }
 
         // PV1.10
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('HospitalService', 3, $data->getPositionalState());
-        $this->setFieldHospitalService($codec->extractComponent($data));
+        $this->checkFieldLength('HospitalService', 3, $datagram->getPositionalState());
+        $this->setFieldHospitalService($codec->extractComponent($datagram));
 
         // PV1.11
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('TemporaryLocation', 80, $data->getPositionalState());
+        $this->checkFieldLength('TemporaryLocation', 80, $datagram->getPositionalState());
         $sequence = [1,1,1,[1,1,1],1,1,1,1,1,[1,1,1,1],[1,1,1]];
         list(
             $pointOfCare,
@@ -3511,7 +3511,7 @@ class Pv1Segment extends AbstractSegment
                 $assigningAuthorityForLocationUniversalId,
                 $assigningAuthorityForLocationUniversalIdType,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldTemporaryLocation(
             $pointOfCare,
             $room,
@@ -3534,35 +3534,35 @@ class Pv1Segment extends AbstractSegment
         );
 
         // PV1.12
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PreadmitTestIndicator', 2, $data->getPositionalState());
-        $this->setFieldPreadmitTestIndicator($codec->extractComponent($data));
+        $this->checkFieldLength('PreadmitTestIndicator', 2, $datagram->getPositionalState());
+        $this->setFieldPreadmitTestIndicator($codec->extractComponent($datagram));
 
         // PV1.13
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('ReadmissionIndicator', 2, $data->getPositionalState());
-        $this->setFieldReadmissionIndicator($codec->extractComponent($data));
+        $this->checkFieldLength('ReadmissionIndicator', 2, $datagram->getPositionalState());
+        $this->setFieldReadmissionIndicator($codec->extractComponent($datagram));
 
         // PV1.14
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('AdmitSource', 6, $data->getPositionalState());
-        $this->setFieldAdmitSource($codec->extractComponent($data));
+        $this->checkFieldLength('AdmitSource', 6, $datagram->getPositionalState());
+        $this->setFieldAdmitSource($codec->extractComponent($datagram));
 
         // PV1.15
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('AmbulatoryStatus', 2, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, [1]);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('AmbulatoryStatus', 2, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, [1]);
             $first = false;
         }
         foreach ($repetitions as list($value,)) {
@@ -3570,22 +3570,22 @@ class Pv1Segment extends AbstractSegment
         }
 
         // PV1.16
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('VipIndicator', 2, $data->getPositionalState());
-        $this->setFieldVipIndicator($codec->extractComponent($data));
+        $this->checkFieldLength('VipIndicator', 2, $datagram->getPositionalState());
+        $this->setFieldVipIndicator($codec->extractComponent($datagram));
 
         // PV1.17
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,[1,1,1,1,1],1,1,1,1,1,1,[1,1,1],1,1,1,1,[1,1,1],1,[1,1,1,1,1,1],[[1,1],[1,1]],1,[1,1],[1,1],1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('AdmittingDoctor', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('AdmittingDoctor', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3732,17 +3732,17 @@ class Pv1Segment extends AbstractSegment
         }
 
         // PV1.18
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PatientType', 2, $data->getPositionalState());
-        $this->setFieldPatientType($codec->extractComponent($data));
+        $this->checkFieldLength('PatientType', 2, $datagram->getPositionalState());
+        $this->setFieldPatientType($codec->extractComponent($datagram));
 
         // PV1.19
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('VisitNumber', 250, $data->getPositionalState());
+        $this->checkFieldLength('VisitNumber', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,[1,1,1],1,[1,1,1],1,1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         list(
             $idNumber,
@@ -3783,7 +3783,7 @@ class Pv1Segment extends AbstractSegment
                 $assigningAgencyAltCodingSystemVersionId,
                 $assigningAgencyOriginalText,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldVisitNumber(
             $idNumber,
             $checkDigit,
@@ -3818,15 +3818,15 @@ class Pv1Segment extends AbstractSegment
         );
 
         // PV1.20
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,[1,1]];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('FinancialClass', 50, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('FinancialClass', 50, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -3845,35 +3845,35 @@ class Pv1Segment extends AbstractSegment
         }
 
         // PV1.21
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('ChargePriceIndicator', 2, $data->getPositionalState());
-        $this->setFieldChargePriceIndicator($codec->extractComponent($data));
+        $this->checkFieldLength('ChargePriceIndicator', 2, $datagram->getPositionalState());
+        $this->setFieldChargePriceIndicator($codec->extractComponent($datagram));
 
         // PV1.22
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('CourtesyCode', 2, $data->getPositionalState());
-        $this->setFieldCourtesyCode($codec->extractComponent($data));
+        $this->checkFieldLength('CourtesyCode', 2, $datagram->getPositionalState());
+        $this->setFieldCourtesyCode($codec->extractComponent($datagram));
 
         // PV1.23
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('CreditRating', 2, $data->getPositionalState());
-        $this->setFieldCreditRating($codec->extractComponent($data));
+        $this->checkFieldLength('CreditRating', 2, $datagram->getPositionalState());
+        $this->setFieldCreditRating($codec->extractComponent($datagram));
 
         // PV1.24
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('ContractCode', 2, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, [1]);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('ContractCode', 2, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, [1]);
             $first = false;
         }
         foreach ($repetitions as list($value,)) {
@@ -3881,14 +3881,14 @@ class Pv1Segment extends AbstractSegment
         }
 
         // PV1.25
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('ContractEffectiveDate', 8, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, [1]);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('ContractEffectiveDate', 8, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, [1]);
             $first = false;
         }
         foreach ($repetitions as list($value,)) {
@@ -3896,14 +3896,14 @@ class Pv1Segment extends AbstractSegment
         }
 
         // PV1.26
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('ContractAmount', 12, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, [1]);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('ContractAmount', 12, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, [1]);
             $first = false;
         }
         foreach ($repetitions as list($value,)) {
@@ -3911,14 +3911,14 @@ class Pv1Segment extends AbstractSegment
         }
 
         // PV1.27
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('ContractPeriod', 3, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, [1]);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('ContractPeriod', 3, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, [1]);
             $first = false;
         }
         foreach ($repetitions as list($value,)) {
@@ -3926,73 +3926,73 @@ class Pv1Segment extends AbstractSegment
         }
 
         // PV1.28
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('InterestCode', 2, $data->getPositionalState());
-        $this->setFieldInterestCode($codec->extractComponent($data));
+        $this->checkFieldLength('InterestCode', 2, $datagram->getPositionalState());
+        $this->setFieldInterestCode($codec->extractComponent($datagram));
 
         // PV1.29
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('TransferToBadDebtCode', 4, $data->getPositionalState());
-        $this->setFieldTransferToBadDebtCode($codec->extractComponent($data));
+        $this->checkFieldLength('TransferToBadDebtCode', 4, $datagram->getPositionalState());
+        $this->setFieldTransferToBadDebtCode($codec->extractComponent($datagram));
 
         // PV1.30
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('TransferToBadDebtDate', 8, $data->getPositionalState());
-        $this->setFieldTransferToBadDebtDate($codec->extractComponent($data));
+        $this->checkFieldLength('TransferToBadDebtDate', 8, $datagram->getPositionalState());
+        $this->setFieldTransferToBadDebtDate($codec->extractComponent($datagram));
 
         // PV1.31
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('BadDebtAgencyCode', 10, $data->getPositionalState());
-        $this->setFieldBadDebtAgencyCode($codec->extractComponent($data));
+        $this->checkFieldLength('BadDebtAgencyCode', 10, $datagram->getPositionalState());
+        $this->setFieldBadDebtAgencyCode($codec->extractComponent($datagram));
 
         // PV1.32
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('BadDebtTransferAmount', 12, $data->getPositionalState());
-        $this->setFieldBadDebtTransferAmount($codec->extractComponent($data));
+        $this->checkFieldLength('BadDebtTransferAmount', 12, $datagram->getPositionalState());
+        $this->setFieldBadDebtTransferAmount($codec->extractComponent($datagram));
 
         // PV1.33
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('BadDebtRecoveryAmount', 12, $data->getPositionalState());
-        $this->setFieldBadDebtRecoveryAmount($codec->extractComponent($data));
+        $this->checkFieldLength('BadDebtRecoveryAmount', 12, $datagram->getPositionalState());
+        $this->setFieldBadDebtRecoveryAmount($codec->extractComponent($datagram));
 
         // PV1.34
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('DeleteAccountIndicator', 1, $data->getPositionalState());
-        $this->setFieldDeleteAccountIndicator($codec->extractComponent($data));
+        $this->checkFieldLength('DeleteAccountIndicator', 1, $datagram->getPositionalState());
+        $this->setFieldDeleteAccountIndicator($codec->extractComponent($datagram));
 
         // PV1.35
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('DeleteAccountDate', 8, $data->getPositionalState());
-        $this->setFieldDeleteAccountDate($codec->extractComponent($data));
+        $this->checkFieldLength('DeleteAccountDate', 8, $datagram->getPositionalState());
+        $this->setFieldDeleteAccountDate($codec->extractComponent($datagram));
 
         // PV1.36
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('DischargeDisposition', 3, $data->getPositionalState());
-        $this->setFieldDischargeDisposition($codec->extractComponent($data));
+        $this->checkFieldLength('DischargeDisposition', 3, $datagram->getPositionalState());
+        $this->setFieldDischargeDisposition($codec->extractComponent($datagram));
 
         // PV1.37
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('DischargedToLocation', 47, $data->getPositionalState());
+        $this->checkFieldLength('DischargedToLocation', 47, $datagram->getPositionalState());
         $sequence = [1,[1,1]];
         list(
             $dischargeLocation,
@@ -4000,7 +4000,7 @@ class Pv1Segment extends AbstractSegment
                 $effectiveDateTime,
                 $effectiveDateDegreeOfPrecision,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldDischargedToLocation(
             $dischargeLocation,
             $effectiveDateTime,
@@ -4008,10 +4008,10 @@ class Pv1Segment extends AbstractSegment
         );
 
         // PV1.38
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('DietType', 250, $data->getPositionalState());
+        $this->checkFieldLength('DietType', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,1,1,1];
         list(
             $identifier,
@@ -4020,7 +4020,7 @@ class Pv1Segment extends AbstractSegment
             $altIdentifier,
             $altText,
             $nameOfAltCodingSystem,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldDietType(
             $identifier,
             $text,
@@ -4031,31 +4031,31 @@ class Pv1Segment extends AbstractSegment
         );
 
         // PV1.39
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('ServicingFacility', 2, $data->getPositionalState());
-        $this->setFieldServicingFacility($codec->extractComponent($data));
+        $this->checkFieldLength('ServicingFacility', 2, $datagram->getPositionalState());
+        $this->setFieldServicingFacility($codec->extractComponent($datagram));
 
         // PV1.40
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('BedStatus', 1, $data->getPositionalState());
-        $this->setFieldBedStatus($codec->extractComponent($data));
+        $this->checkFieldLength('BedStatus', 1, $datagram->getPositionalState());
+        $this->setFieldBedStatus($codec->extractComponent($datagram));
 
         // PV1.41
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('AccountStatus', 2, $data->getPositionalState());
-        $this->setFieldAccountStatus($codec->extractComponent($data));
+        $this->checkFieldLength('AccountStatus', 2, $datagram->getPositionalState());
+        $this->setFieldAccountStatus($codec->extractComponent($datagram));
 
         // PV1.42
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PendingLocation', 80, $data->getPositionalState());
+        $this->checkFieldLength('PendingLocation', 80, $datagram->getPositionalState());
         $sequence = [1,1,1,[1,1,1],1,1,1,1,1,[1,1,1,1],[1,1,1]];
         list(
             $pointOfCare,
@@ -4082,7 +4082,7 @@ class Pv1Segment extends AbstractSegment
                 $assigningAuthorityForLocationUniversalId,
                 $assigningAuthorityForLocationUniversalIdType,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldPendingLocation(
             $pointOfCare,
             $room,
@@ -4105,10 +4105,10 @@ class Pv1Segment extends AbstractSegment
         );
 
         // PV1.43
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('PriorTemporaryLocation', 80, $data->getPositionalState());
+        $this->checkFieldLength('PriorTemporaryLocation', 80, $datagram->getPositionalState());
         $sequence = [1,1,1,[1,1,1],1,1,1,1,1,[1,1,1,1],[1,1,1]];
         list(
             $pointOfCare,
@@ -4135,7 +4135,7 @@ class Pv1Segment extends AbstractSegment
                 $assigningAuthorityForLocationUniversalId,
                 $assigningAuthorityForLocationUniversalIdType,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldPriorTemporaryLocation(
             $pointOfCare,
             $room,
@@ -4158,30 +4158,30 @@ class Pv1Segment extends AbstractSegment
         );
 
         // PV1.44
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('AdmitDatetime', 26, $data->getPositionalState());
+        $this->checkFieldLength('AdmitDatetime', 26, $datagram->getPositionalState());
         $sequence = [1,1];
         list(
             $time,
             $degreeOfPrecision,
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldAdmitDatetime(
             $time,
             $degreeOfPrecision
         );
 
         // PV1.45
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,1];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('DischargeDatetime', 26, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('DischargeDatetime', 26, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {
@@ -4196,38 +4196,38 @@ class Pv1Segment extends AbstractSegment
         }
 
         // PV1.46
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('CurrentPatientBalance', 12, $data->getPositionalState());
-        $this->setFieldCurrentPatientBalance($codec->extractComponent($data));
+        $this->checkFieldLength('CurrentPatientBalance', 12, $datagram->getPositionalState());
+        $this->setFieldCurrentPatientBalance($codec->extractComponent($datagram));
 
         // PV1.47
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('TotalCharges', 12, $data->getPositionalState());
-        $this->setFieldTotalCharges($codec->extractComponent($data));
+        $this->checkFieldLength('TotalCharges', 12, $datagram->getPositionalState());
+        $this->setFieldTotalCharges($codec->extractComponent($datagram));
 
         // PV1.48
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('TotalAdjustments', 12, $data->getPositionalState());
-        $this->setFieldTotalAdjustments($codec->extractComponent($data));
+        $this->checkFieldLength('TotalAdjustments', 12, $datagram->getPositionalState());
+        $this->setFieldTotalAdjustments($codec->extractComponent($datagram));
 
         // PV1.49
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('TotalPayments', 12, $data->getPositionalState());
-        $this->setFieldTotalPayments($codec->extractComponent($data));
+        $this->checkFieldLength('TotalPayments', 12, $datagram->getPositionalState());
+        $this->setFieldTotalPayments($codec->extractComponent($datagram));
 
         // PV1.50
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('AltVisitId', 250, $data->getPositionalState());
+        $this->checkFieldLength('AltVisitId', 250, $datagram->getPositionalState());
         $sequence = [1,1,1,[1,1,1],1,[1,1,1],1,1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         list(
             $idNumber,
@@ -4268,7 +4268,7 @@ class Pv1Segment extends AbstractSegment
                 $assigningAgencyAltCodingSystemVersionId,
                 $assigningAgencyOriginalText,
             ),
-        ) = $this->extractComponents($data, $codec, $sequence);
+        ) = $this->extractComponents($datagram, $codec, $sequence);
         $this->setFieldAltVisitId(
             $idNumber,
             $checkDigit,
@@ -4303,22 +4303,22 @@ class Pv1Segment extends AbstractSegment
         );
 
         // PV1.51
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
-        $this->checkFieldLength('VisitIndicator', 1, $data->getPositionalState());
-        $this->setFieldVisitIndicator($codec->extractComponent($data));
+        $this->checkFieldLength('VisitIndicator', 1, $datagram->getPositionalState());
+        $this->setFieldVisitIndicator($codec->extractComponent($datagram));
 
         // PV1.52
-        if (false === $codec->advanceToField($data)) {
+        if (false === $codec->advanceToField($datagram)) {
             return false;
         }
         $sequence = [1,[1,1,1,1,1],1,1,1,1,1,1,[1,1,1],1,1,1,1,[1,1,1],1,[1,1,1,1,1,1],[[1,1],[1,1]],1,[1,1],[1,1],1,[1,1,1,1,1,1,1,1,1],[1,1,1,1,1,1,1,1,1]];
         $repetitions = [];
         $first = true;
-        while ($first || false !== $codec->advanceToRepetition($data)) {
-            $this->checkRepetitionLength('OtherHealthcareProvider', 250, $data->getPositionalState());
-            $repetitions[] = $this->extractComponents($data, $codec, $sequence);
+        while ($first || false !== $codec->advanceToRepetition($datagram)) {
+            $this->checkRepetitionLength('OtherHealthcareProvider', 250, $datagram->getPositionalState());
+            $repetitions[] = $this->extractComponents($datagram, $codec, $sequence);
             $first = false;
         }
         foreach ($repetitions as $components) {

--- a/lib/Segment/Pv1Segment.php
+++ b/lib/Segment/Pv1Segment.php
@@ -2801,7 +2801,7 @@ class Pv1Segment extends AbstractSegment
         // PV1.1
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'PV1 Segment data contains too few required fields.'
             );
         }
         $this->checkFieldLength('SetId', 4, $data->getPositionalState());
@@ -2810,7 +2810,7 @@ class Pv1Segment extends AbstractSegment
         // PV1.2
         if (false === $codec->advanceToField($data)) {
             throw new SegmentError(
-                'MSH Segment data contains too few required fields.'
+                'PV1 Segment data contains too few required fields.'
             );
         }
         $this->checkFieldLength('PatientClass', 1, $data->getPositionalState());

--- a/lib/Segment/SegmentInterface.php
+++ b/lib/Segment/SegmentInterface.php
@@ -7,5 +7,12 @@ use Hl7v2\Encoding\Datagram;
 
 interface SegmentInterface
 {
-    public function fromDatagram(Datagram $data, Codec $codec);
+    /**
+     * Decode the Segment, from the supplied Datagram, using the Codec.
+     *
+     * @param \Hl7v2\Encoding\Datagram $datagram
+     * @param \Hl7v2\Encoding\Codec $codec
+     * @throws \Hl7v2\Exception\SegmentError
+     */
+    public function fromDatagram(Datagram $datagram, Codec $codec);
 }

--- a/meta/Generator/DataType/AbstractDataTypeGenerator.php
+++ b/meta/Generator/DataType/AbstractDataTypeGenerator.php
@@ -17,9 +17,13 @@ abstract class AbstractDataTypeGenerator implements DataTypeGeneratorInterface
         $this->context = $context;
         $this->typeId = $typeId;
         $this->typeName = $typeInfo['name'];
-        if (isset($typeInfo['len']) && is_numeric($typeInfo['len'])) {
-            $this->maxLen = (int) $typeInfo['len'];
-            $this->constants[] = ['MAX_LEN', $this->maxLen];
+        if (array_key_exists('len', $typeInfo)) {
+            if (is_numeric($typeInfo['len'])) {
+                $this->maxLen = (int) $typeInfo['len'];
+                $this->constants[] = ['MAX_LEN', (string) $this->maxLen];
+            } elseif (is_null($typeInfo['len'])) {
+                $this->constants[] = ['MAX_LEN', 'null'];
+            }
         }
     }
 

--- a/meta/Generator/DataType/AbstractDataTypeGenerator.php
+++ b/meta/Generator/DataType/AbstractDataTypeGenerator.php
@@ -34,7 +34,7 @@ abstract class AbstractDataTypeGenerator implements DataTypeGeneratorInterface
 
     public function getClass()
     {
-        return $this->context->dataTypeIdToFQClassName($this->typeId);
+        return $this->context->dataTypeIdToClass($this->typeId);
     }
 
     public function getDescription()

--- a/meta/Generator/DataType/ComponentDataTypeGenerator.php
+++ b/meta/Generator/DataType/ComponentDataTypeGenerator.php
@@ -47,7 +47,7 @@ class ComponentDataTypeGenerator extends AbstractDataTypeGenerator
         foreach ($this->components as $component) {
             $properties[] = [
                 $this->componentNameToPropertyName($component['name']),
-                $this->context->dataTypeIdToFQClassName($component['type'])
+                $this->context->dataTypeIdToClass($component['type'])
             ];
         }
 
@@ -65,7 +65,7 @@ class ComponentDataTypeGenerator extends AbstractDataTypeGenerator
             $propertyName = $this->componentNameToPropertyName($component['name']);
             $accessors[] = [
                 $this->componentNameToAccessorName($component['name']),
-                $this->context->dataTypeIdToFQClassName($component['type']),
+                $this->context->dataTypeIdToClass($component['type']),
                 "        return \$this->{$propertyName};",
             ];
         }

--- a/meta/Generator/DataType/InheritedDataTypeGenerator.php
+++ b/meta/Generator/DataType/InheritedDataTypeGenerator.php
@@ -13,6 +13,6 @@ class InheritedDataTypeGenerator extends AbstractDataTypeGenerator
 
     public function getInheritanceClass()
     {
-        return $this->context->dataTypeIdToFQClassName($this->parentDataTypeId);
+        return $this->context->dataTypeIdToClass($this->parentDataTypeId);
     }
 }

--- a/meta/Generator/Segment/SegmentGenerator.php
+++ b/meta/Generator/Segment/SegmentGenerator.php
@@ -182,7 +182,7 @@ class SegmentGenerator
                 $this->mshDatagramBody($b, $f);
                 continue;
             }
-            $b[] = 'if (false === $codec->advanceToField($data)) {';
+            $b[] = 'if (false === $codec->advanceToField($datagram)) {';
             if ($this->lastRequiredFieldnum >= $f->num) {
                 $b[] = '    throw new SegmentError(';
                 $b[] = "        '{$this->segmentId} Segment data contains too few required fields.'";
@@ -242,11 +242,11 @@ class SegmentGenerator
             $b[] = "{$in1}\$sequence = {$subcompSequenceAsString};";
             $b[] = "{$in1}\$repetitions = [];";
             $b[] = "{$in1}\$first = true;";
-            $b[] = "{$in1}while (\$first || false !== \$codec->advanceToRepetition(\$data)) {";
+            $b[] = "{$in1}while (\$first || false !== \$codec->advanceToRepetition(\$datagram)) {";
             if ($f->len) {
-                $b[] = "{$in2}\$this->checkRepetitionLength('{$f->name}', {$f->len}, \$data->getPositionalState());";
+                $b[] = "{$in2}\$this->checkRepetitionLength('{$f->name}', {$f->len}, \$datagram->getPositionalState());";
             }
-            $b[] = "{$in2}\$repetitions[] = \$this->extractComponents(\$data, \$codec, \$sequence);";
+            $b[] = "{$in2}\$repetitions[] = \$this->extractComponents(\$datagram, \$codec, \$sequence);";
             $b[] = "{$in2}\$first = false;";
             $b[] = "{$in1}}";
             $b[] = "{$in1}foreach (\$repetitions as \$components) {";
@@ -263,14 +263,14 @@ class SegmentGenerator
             $b[] = "{$in1}}";
         } elseif ($f->isComponentType()) {
             if ($f->len) {
-                $b[] = "{$in1}\$this->checkFieldLength('{$f->name}', {$f->len}, \$data->getPositionalState());";
+                $b[] = "{$in1}\$this->checkFieldLength('{$f->name}', {$f->len}, \$datagram->getPositionalState());";
             }
             $pCount = sizeof($properties);
             $b[] = "{$in1}\$sequence = {$subcompSequenceAsString};";
             $i = 0;
             $this->sequencedListUnpack($subcompSequence, $b, $i, $indentLen+0, $properties);
             $b = array_slice($b, 0, -1);
-            $b[] = "{$in1}) = \$this->extractComponents(\$data, \$codec, \$sequence);";
+            $b[] = "{$in1}) = \$this->extractComponents(\$datagram, \$codec, \$sequence);";
             $b[] = "{$in1}\$this->setField{$f->name}{$f->suffixForMutator}(";
             for ($i = 0; $i+1 < $pCount; $i++) {
                 $b[] = "{$in2}{$properties[$i]},";
@@ -280,11 +280,11 @@ class SegmentGenerator
         } elseif ($f->repeated) {
             $b[] = "{$in1}\$repetitions = [];";
             $b[] = "{$in1}\$first = true;";
-            $b[] = "{$in1}while (\$first || false !== \$codec->advanceToRepetition(\$data)) {";
+            $b[] = "{$in1}while (\$first || false !== \$codec->advanceToRepetition(\$datagram)) {";
             if ($f->len) {
-                $b[] = "{$in2}\$this->checkRepetitionLength('{$f->name}', {$f->len}, \$data->getPositionalState());";
+                $b[] = "{$in2}\$this->checkRepetitionLength('{$f->name}', {$f->len}, \$datagram->getPositionalState());";
             }
-            $b[] = "{$in2}\$repetitions[] = \$this->extractComponents(\$data, \$codec, [1]);";
+            $b[] = "{$in2}\$repetitions[] = \$this->extractComponents(\$datagram, \$codec, [1]);";
             $b[] = "{$in2}\$first = false;";
             $b[] = "{$in1}}";
             $b[] = "{$in1}foreach (\$repetitions as list(\$value,)) {";
@@ -292,20 +292,20 @@ class SegmentGenerator
             $b[] = "{$in1}}";
         } else {
             if ($f->len) {
-                $b[] = "{$in1}\$this->checkFieldLength('{$f->name}', {$f->len}, \$data->getPositionalState());";
+                $b[] = "{$in1}\$this->checkFieldLength('{$f->name}', {$f->len}, \$datagram->getPositionalState());";
             }
-            $b[] = "{$in1}\$this->setField{$f->name}{$f->suffixForMutator}(\$codec->extractComponent(\$data));";
+            $b[] = "{$in1}\$this->setField{$f->name}{$f->suffixForMutator}(\$codec->extractComponent(\$datagram));";
         }
     }
 
     private function mshDatagramBody(&$b, SegmentField $f)
     {
         if ($f->num === 1) {
-            $b[] = '$encodingParams = $data->getEncodingParameters();';
+            $b[] = '$encodingParams = $datagram->getEncodingParameters();';
             $b[] = '$this->setFieldFieldSeparator($encodingParams->getFieldSep());';
             $b[] = '';
         } elseif ($f->num === 2) {
-            $b[] = '$codec->advanceToField($data);';
+            $b[] = '$codec->advanceToField($datagram);';
             $b[] = '$this->setFieldEncodingCharacters(';
             $b[] = '    $encodingParams->getComponentSep()';
             $b[] = '    . $encodingParams->getRepetitionSep()';

--- a/meta/Generator/Segment/SegmentGenerator.php
+++ b/meta/Generator/Segment/SegmentGenerator.php
@@ -4,13 +4,23 @@ namespace Hl7v2\Meta\Generator\Segment;
 
 use Hl7v2\Meta\Helper\DataTypeContext;
 use Hl7v2\Meta\Helper\SegmentContext;
+use Hl7v2\Meta\Helper\SegmentField;
 use Hl7v2\Meta\Helper\Util;
 
 class SegmentGenerator
 {
     protected $constants = [];
+    /**
+     * @var \Hl7v2\Meta\Helper\DataTypeContext
+     */
     protected $dataTypeContext;
+    /**
+     * @var \Hl7v2\Meta\Helper\SegmentContext
+     */
     protected $segmentContext;
+    /**
+     * @var \Hl7v2\Meta\Helper\SegmentField[]
+     */
     protected $fields;
     protected $lastRequiredFieldnum;
     protected $segmentId;
@@ -238,7 +248,7 @@ class SegmentGenerator
         return array_slice($b, 0, -1);
     }
 
-    private function mshDatagramBody(&$b, $f)
+    private function mshDatagramBody(&$b, SegmentField $f)
     {
         if ($f->num === 1) {
             $b[] = '$encodingParams = $data->getEncodingParameters();';
@@ -288,7 +298,7 @@ class SegmentGenerator
         return lcfirst($fieldName);
     }
 
-    private function adderForRepeatedComponentType($f)
+    private function adderForRepeatedComponentType(SegmentField $f)
     {
         $args = [];
         $methodName =  "addField{$f->name}";
@@ -331,7 +341,7 @@ class SegmentGenerator
         return [$methodName, $args, $body];
     }
 
-    private function setterForComponentType($f)
+    private function setterForComponentType(SegmentField $f)
     {
         $args = [];
         $methodName =  "setField{$f->name}";
@@ -363,7 +373,7 @@ class SegmentGenerator
         return [$methodName, $args, $body];
     }
 
-    private function adderForRepeatedSimpleType($f)
+    private function adderForRepeatedSimpleType(SegmentField $f)
     {
         $methodName =  "addField{$f->name}";
         $propertyName = $this->fieldNameToPropertyName($f->name);
@@ -390,7 +400,7 @@ class SegmentGenerator
         return [$methodName, [['string', 'value', true]], $body];
     }
 
-    private function setterForSimpleType($f)
+    private function setterForSimpleType(SegmentField $f)
     {
         $methodName =  "setField{$f->name}";
         $propertyName = $this->fieldNameToPropertyName($f->name);

--- a/meta/Generator/Segment/SegmentGenerator.php
+++ b/meta/Generator/Segment/SegmentGenerator.php
@@ -43,7 +43,7 @@ class SegmentGenerator
 
     public function getClass()
     {
-        return $this->segmentContext->segmentIdToFQClassName($this->segmentId);
+        return $this->segmentContext->segmentIdToClass($this->segmentId);
     }
 
     public function getDescription()
@@ -71,7 +71,7 @@ class SegmentGenerator
                 $properties[] = $p;
                 continue;
             }
-            $type = '\\' . $this->dataTypeContext->dataTypeIdToFQClassName($f->type);
+            $type = '\\' . $this->dataTypeContext->dataTypeIdToClass($f->type);
             if ($f->repeated) {
                 $type .= '[]';
             }
@@ -120,7 +120,7 @@ class SegmentGenerator
                 continue;
             }
             $propertyName = $this->fieldNameToPropertyName($f->name);
-            $returnType = $this->dataTypeContext->dataTypeIdToFQClassName($f->type);
+            $returnType = $this->dataTypeContext->dataTypeIdToClass($f->type);
             if ($f->repeated) {
                 $returnType .= '[]';
             }

--- a/meta/Generator/Segment/SegmentGenerator.php
+++ b/meta/Generator/Segment/SegmentGenerator.php
@@ -161,7 +161,7 @@ class SegmentGenerator
             $b[] = 'if (false === $codec->advanceToField($data)) {';
             if ($this->lastRequiredFieldnum >= $f->num) {
                 $b[] = '    throw new SegmentError(';
-                $b[] = '        \'MSH Segment data contains too few required fields.\'';
+                $b[] = "        '{$this->segmentId} Segment data contains too few required fields.'";
                 $b[] = '    );';
             } else {
                 $b[] = '    return false;';

--- a/meta/Generator/Segment/SegmentGenerator.php
+++ b/meta/Generator/Segment/SegmentGenerator.php
@@ -73,7 +73,7 @@ class SegmentGenerator
 
         foreach ($this->fields as $f) {
             $p = [
-                $this->fieldNameToPropertyName($f->name),
+                $f->nameForProperty,
             ];
             if ($f->reserved) {
                 $p[] = false;
@@ -129,7 +129,7 @@ class SegmentGenerator
             if ($f->reserved) {
                 continue;
             }
-            $propertyName = $this->fieldNameToPropertyName($f->name);
+            $propertyName = $f->nameForProperty;
             $returnType = $this->dataTypeContext->dataTypeIdToClass($f->type);
             if ($f->repeated) {
                 $returnType .= '[]';
@@ -293,16 +293,11 @@ class SegmentGenerator
         return substr($s, 0, -1) . ']';
     }
 
-    private function fieldNameToPropertyName($fieldName)
-    {
-        return lcfirst($fieldName);
-    }
-
     private function adderForRepeatedComponentType(SegmentField $f)
     {
         $args = [];
         $methodName =  "addField{$f->name}";
-        $propertyName = $this->fieldNameToPropertyName($f->name);
+        $propertyName = $f->nameForProperty;
         $body = [
             "\${$propertyName} = \$this",
             "    ->dataTypeFactory",
@@ -345,7 +340,7 @@ class SegmentGenerator
     {
         $args = [];
         $methodName =  "setField{$f->name}";
-        $propertyName = $this->fieldNameToPropertyName($f->name);
+        $propertyName = $f->nameForProperty;
         $body = [
             "\$this->{$propertyName} = \$this",
             "    ->dataTypeFactory",
@@ -376,7 +371,7 @@ class SegmentGenerator
     private function adderForRepeatedSimpleType(SegmentField $f)
     {
         $methodName =  "addField{$f->name}";
-        $propertyName = $this->fieldNameToPropertyName($f->name);
+        $propertyName = $f->nameForProperty;
         $body = [
             "\${$propertyName} = \$this",
             "    ->dataTypeFactory",
@@ -403,7 +398,7 @@ class SegmentGenerator
     private function setterForSimpleType(SegmentField $f)
     {
         $methodName =  "setField{$f->name}";
-        $propertyName = $this->fieldNameToPropertyName($f->name);
+        $propertyName = $f->nameForProperty;
         $body = [
             "\$this->{$propertyName} = \$this",
             "    ->dataTypeFactory",

--- a/meta/Helper/DataTypeContext.php
+++ b/meta/Helper/DataTypeContext.php
@@ -18,12 +18,24 @@ class DataTypeContext
         return $this->namespace;
     }
 
-    public function dataTypeIdToFQClassName($typeId)
+    /**
+     * Fully qualified class name of the DataType with the specified typeId.
+     *
+     * @param string $typeId
+     * @return string
+     */
+    public function dataTypeIdToClass($typeId)
     {
         $className = $this->dataTypeIdToClassName($typeId);
         return "{$this->namespace}\\{$className}";
     }
 
+    /**
+     * Class name of the DataType with the specified typeId.
+     *
+     * @param string $typeId
+     * @return string
+     */
     public function dataTypeIdToClassName($dataTypeId)
     {
         return ucfirst(strtolower($dataTypeId)) . self::CLASS_SUFFIX;

--- a/meta/Helper/DataTypeContext.php
+++ b/meta/Helper/DataTypeContext.php
@@ -5,6 +5,7 @@ namespace Hl7v2\Meta\Helper;
 class DataTypeContext
 {
     const CLASS_SUFFIX = 'DataType';
+    const INTERFACE_NAME = 'DataTypeInterface';
 
     protected $namespace;
 
@@ -16,6 +17,11 @@ class DataTypeContext
     public function getNamespace()
     {
         return $this->namespace;
+    }
+
+    public function interfaceClass()
+    {
+        return "{$this->namespace}\\" . self::INTERFACE_NAME;
     }
 
     /**

--- a/meta/Helper/DataTypeResolver.php
+++ b/meta/Helper/DataTypeResolver.php
@@ -76,7 +76,7 @@ class DataTypeResolver
     public function getReflectionClass($typeId)
     {
         if (! array_key_exists($typeId, $this->types)) {
-            $class = $this->context->dataTypeIdToFQClassName($typeId);
+            $class = $this->context->dataTypeIdToClass($typeId);
             if (!class_exists($class)) {
                 throw new RuntimeException("Cannot perform Reflection of DataType {$typeId}; class cannot be loaded.");
             }

--- a/meta/Helper/DataTypeResolver.php
+++ b/meta/Helper/DataTypeResolver.php
@@ -47,7 +47,16 @@ class DataTypeResolver
             }
         }
 
-        return $graph->resolve();
+        $path = $graph->resolve();
+
+        foreach (array_keys($nodes) as $element) {
+            if (in_array($element, $path)) {
+                continue;
+            }
+            array_push($path, $element);
+        }
+
+        return $path;
     }
 
     public function isComponentType($typeId)

--- a/meta/Helper/SegmentContext.php
+++ b/meta/Helper/SegmentContext.php
@@ -18,12 +18,24 @@ class SegmentContext
         return $this->namespace;
     }
 
-    public function segmentIdToFQClassName($segmentId)
+    /**
+     * Fully qualified class name of the Segment with the specified $segmentId.
+     *
+     * @param string $typeId
+     * @return string
+     */
+    public function segmentIdToClass($segmentId)
     {
         $className = $this->segmentIdToClassName($segmentId);
         return "{$this->namespace}\\{$className}";
     }
 
+    /**
+     * Class name of the Segment with the specified $segmentId.
+     *
+     * @param string $typeId
+     * @return string
+     */
     public function segmentIdToClassName($segmentId)
     {
         return ucfirst(strtolower($segmentId)) . self::CLASS_SUFFIX;

--- a/meta/Helper/SegmentField.php
+++ b/meta/Helper/SegmentField.php
@@ -20,6 +20,11 @@ class SegmentField
      */
     public $name;
     /**
+     * Name of Segment object property (e.g. $characterEncoding).
+     * @var string
+     */
+    public $nameForProperty;
+    /**
      * Numerical index of Field (beginning with one).
      * @var int
      */
@@ -59,6 +64,8 @@ class SegmentField
         $this->id = $id;
         $this->num = $num;
         $this->name = $this->prepareName($fieldInfo['name']);
+        $this->nameForProperty = lcfirst($this->name);
+
         if (array_key_exists('reserved', $fieldInfo)
             && true === $fieldInfo['reserved']
         ) {

--- a/meta/Helper/SegmentField.php
+++ b/meta/Helper/SegmentField.php
@@ -4,15 +4,54 @@ namespace Hl7v2\Meta\Helper;
 
 class SegmentField
 {
+    /**
+     * Textual Field ID (e.g. MSH.18)
+     * @var string
+     */
     public $id;
+    /**
+     * Permitted length of Field.
+     * @var null|int
+     */
     public $len;
+    /**
+     * Name of Field (e.g. CharacterEncoding).
+     * @var string
+     */
     public $name;
+    /**
+     * Numerical index of Field (beginning with one).
+     * @var int
+     */
     public $num;
+    /**
+     * True when the value of the Field may repeat.
+     * @var bool
+     */
     public $repeated = false;
+    /**
+     * Maximum number of value repetitions.
+     * @var null|int
+     */
     public $repeatedCount;
+    /**
+     * True when a value of the Field is mandatory.
+     * @var bool
+     */
     public $required = false;
+    /**
+     * True when the Field is reserved for future use.
+     * @var bool
+     */
     public $reserved = false;
+    /**
+     * DataType type name (e.g. ID).
+     * @var null|string
+     */
     public $type;
+    /**
+     * @var \Hl7v2\Meta\Helper\DataTypeResolver
+     */
     public $typeResolver;
 
     public function __construct($id, $num, DataTypeResolver $typeResolver, $fieldInfo)

--- a/meta/data/dataTypes.yml
+++ b/meta/data/dataTypes.yml
@@ -230,6 +230,32 @@ DTM:
     name: Date/Time
     len: 24
 
+ED:
+    name: Encapsulated Data
+    components:
+        -
+          name: SourceApplication
+          type: HD
+          len: 227
+        -
+          name: TypeOfData
+          required: true
+          type: ID
+          len: 9
+        -
+          name: DataSubtype
+          type: ID
+          len: 18
+        -
+          name: Encoding
+          required: true
+          type: ID
+          len: 6
+        -
+          name: Data
+          required: true
+          type: TX
+
 EI:
     name: Entity Identifier
     len: 427
@@ -303,6 +329,11 @@ FN:
           name: SurnameFromPartner
           type: ST
           len: 50
+
+FT:
+    name: Formatted Text
+    extends: ST
+    len: ~
 
 HD:
     name: Heirarchical Designator

--- a/meta/data/dataTypes.yml
+++ b/meta/data/dataTypes.yml
@@ -325,6 +325,7 @@ HD:
 ID:
     name: Coded value for HL7 tables
     extends: ST
+    len: ~
 
 IS:
     name: Coded value for user-defined tables

--- a/meta/data/segments.yml
+++ b/meta/data/segments.yml
@@ -744,8 +744,24 @@ OBX:
           len: 20
         -
           name: Observation Value
-          type: TX    # Varies by OBX.2
-          len: ~      # ditto
+          type: variable
+          fieldIdentifiesType: 2
+          types:
+              -
+                type: ED
+              -
+                type: FT
+              -
+                type: NM
+                len: 16
+              -
+                type: ST
+                len: 199
+              -
+                type: TS
+                len: 26
+              -
+                type: TX
           repeat: true
         -
           name: Units

--- a/meta/generateSegments.php
+++ b/meta/generateSegments.php
@@ -41,8 +41,6 @@ $outDir = __DIR__ . '/../lib/Segment';
 $dataTypeContext = new DataTypeContext('Hl7v2\\DataType');
 $segmentContext = new SegmentContext('Hl7v2\\Segment');
 $typeResolver = new DataTypeResolver($dataTypeContext, $dataTypes);
-#dump($typeResolver->getSubcomponentInfo('XPN')); die();
-
 
 # Report missing DataType
 $t = [];
@@ -51,7 +49,16 @@ foreach ($segments as $name => $attr) {
         if (!isset($field['type']) || empty($field['type'])) {
             continue;
         }
-        $t[$field['type']] = true;
+        if ($field['type'] === 'variable') {
+            if (!isset($field['types']) || !is_array($field['types'])) {
+                continue;
+            }
+            foreach ($field['types'] as $typ) {
+                $t[$typ['type']] = true;
+            }
+        } else {
+            $t[$field['type']] = true;
+        }
     }
 }
 $missingTypes = [];

--- a/meta/generateSegments.php
+++ b/meta/generateSegments.php
@@ -56,7 +56,7 @@ foreach ($segments as $name => $attr) {
 }
 $missingTypes = [];
 foreach (array_keys($t) as $id) {
-    if (!class_exists($dataTypeContext->dataTypeIdToFQClassName($id))) {
+    if (!class_exists($dataTypeContext->dataTypeIdToClass($id))) {
         $missingTypes[] = $id;
         continue;
     }

--- a/meta/generateSegments.php
+++ b/meta/generateSegments.php
@@ -145,7 +145,7 @@ foreach ($segments as $segmentId => $segmentAttr) {
     }
 
     $fdgMethod = Method::make('fromDatagram')
-        ->addArgument(new Argument('\\Hl7v2\\Encoding\\Datagram', 'data'))
+        ->addArgument(new Argument('\\Hl7v2\\Encoding\\Datagram', 'datagram'))
         ->addArgument(new Argument('\\Hl7v2\\Encoding\\Codec', 'codec'))
         ->setBody(implode("\n", Util::indentBodyParts($g->getFromDatagramBody())))
     ;


### PR DESCRIPTION
Please tag as v1.1.0.

Changes:-

- Add generation of variable type Segment fields
- Make OBX.5 a variable type Segment field (see  e9373e2)
- Fix a serious bug which caused endlessly repeated decoding of a datagram.
- Fix incorrect segment id in some error messages.
- Fix generation of MAX_LEN const for descendent DataTypes.
- Fix generation of completely independent DataTypes (which were previously omitted).
